### PR TITLE
Add option to show CDR3 AA translation for export alignments

### DIFF
--- a/src/main/java/com/milaboratory/mixcr/cli/ActionExportAlignmentsPretty.java
+++ b/src/main/java/com/milaboratory/mixcr/cli/ActionExportAlignmentsPretty.java
@@ -111,7 +111,7 @@ public class ActionExportAlignmentsPretty implements Action {
                     output.println(">>> Original Description: " + oDescriptions[i] + "\n");
             }
 
-            MultiAlignmentHelper targetAsMultiAlignment = VDJCAlignmentsFormatter.getTargetAsMultiAlignment(alignments, i);
+            MultiAlignmentHelper targetAsMultiAlignment = VDJCAlignmentsFormatter.getTargetAsMultiAlignment(alignments, i, false, actionParameters.isShowTranslations());
             if (targetAsMultiAlignment == null)
                 continue;
             MultiAlignmentHelper[] split = targetAsMultiAlignment.split(80);
@@ -285,6 +285,10 @@ public class ActionExportAlignmentsPretty implements Action {
                 names = {"-d", "--descriptions"})
         public Boolean descr = null;
 
+        @Parameter(description = "Print CDR3 AA translations",
+                names = {"-tr", "--aaTranslations"})
+        public Boolean translations = null;
+
         public Chains getChain() {
             return Util.parseLoci(chain);
         }
@@ -353,6 +357,10 @@ public class ActionExportAlignmentsPretty implements Action {
 
         public boolean isVerbose() {
             return verbose != null && verbose;
+        }
+
+        public boolean isShowTranslations() {
+            return translations != null && translations;
         }
 
         public boolean isOnlyTop() {


### PR DESCRIPTION
This proposed patch adds an option to show the CDR3 AA translation above the NT sequence in ExportAlignmentsPretty.  We've found this useful when looking at many reads.  I'm open to implementation suggestions - one weakness of this approach is that it only seems to report AA if we have full-length CDR3.  I'm extracting this using:

NSequenceWithQuality cdr3NT = vdjcObject.getFeature(GeneFeature.CDR3);

and it's possible another route would also give us a result for partial overlaps.