### PR TITLE
No C gene split in shotgun analyze pipeline

### DIFF
--- a/src/main/java/com/milaboratory/mixcr/cli/CommandAnalyze.java
+++ b/src/main/java/com/milaboratory/mixcr/cli/CommandAnalyze.java
@@ -847,8 +847,7 @@ public abstract class CommandAnalyze extends ACommandWithOutputMiXCR {
         Collection<String> pipelineSpecificAssembleParameters() {
             return Arrays.asList(
                     "-OseparateByV=true",
-                    "-OseparateByJ=true",
-                    "-OseparateByC=true"
+                    "-OseparateByJ=true"
             );
         }
 


### PR DESCRIPTION
Instead each clone nearly guaranteed to be separated into two clones:
  - with specific C gene
  - with `null` C gene