### PR TITLE
allowNoCDR3PartialAlignments for align-rna-seq-bundle

### DIFF
--- a/src/main/resources/mixcr_presets/blocks/01-align.yaml
+++ b/src/main/resources/mixcr_presets/blocks/01-align.yaml
@@ -241,7 +241,7 @@
       maxHits: 5
       relativeMinVFR3CDR3Score: 0.7
       allowPartialAlignments: true
-      allowNoCDR3PartAlignments: false
+      allowNoCDR3PartAlignments: true
       allowChimeras: false
       alignmentBoundaryTolerance: 5
       minChimeraDetectionScore: 120


### PR DESCRIPTION
allow alignments with no CDR3 part for RNAseq align parameters