### PR TITLE
Hotfix for 4.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,7 +143,7 @@ val repseqioVersion = ""
 
 val picocliVersion = "4.6.3"
 val jacksonBomVersion = "2.15.2"
-val milmVersion = "4.0.0"
+val milmVersion = "4.1.0"
 
 val cliktVersion = "3.5.0"
 val jcommanderVersion = "1.72"


### PR DESCRIPTION
fixes freeze on windows with arguments containing ':' characters