### PR TITLE
fix: remove duplicate builtin: prefix in 10x-sc-5gex-gemx-v3 whitelist

### DIFF
--- a/src/main/resources/presets/protocols/10x.yaml
+++ b/src/main/resources/presets/protocols/10x.yaml
@@ -750,7 +750,7 @@
         readsLayout: ReverseOnly
   refineTagsAndSort:
     whitelists:
-      CELL: builtin:builtin:3M-5pgex-jan-2023
+      CELL: builtin:3M-5pgex-jan-2023
     runCorrection: true
     parameters:
       correctionPower: 0.001


### PR DESCRIPTION
The CELL whitelist address had a double "builtin:" prefix which caused an IllegalArgumentException when running refineTagsAndSort.