### PR TITLE
Add missing qc section to ONT single-cell 10x presets

### DIFF
--- a/regression/presets/analyze/10x-ont-sc-3gex-v4.yaml
+++ b/regression/presets/analyze/10x-ont-sc-3gex-v4.yaml
@@ -540,3 +540,34 @@ exportCloneGroups:
       args:
         - CDR3
   sortChainsBy: Auto
+qc:
+  checks:
+    - type: SuccessfullyAlignedReads
+      upper: 0.6
+      middle: 0.4
+      label: Successfully aligned reads
+    - type: UnassignedAlignments
+      upper: 0.4
+      middle: 0.2
+      label: Unassigned alignments in clonotype assembly
+    - type: AlignmentsDroppedLowQuality
+      upper: 0.4
+      middle: 0.2
+      label: Alignments dropped due to low sequence quality
+    - type: ReadsDroppedInTagRefinement
+      upper: 0.5
+      middle: 0.3
+      label: Reads dropped in tags error correction and filtering
+    - type: TagArtificialDiversityEliminated
+      tag: CELL
+      upper: 0.9
+      middle: 0.8
+      label: CELLs artificial diversity eliminated
+    - type: ReadsDroppedInTagFiltering
+      upper: 0.4
+      middle: 0.2
+      label: Reads dropped in tags filtering
+    - type: CellBarcodesWithFoundGroups
+      upper: 0.75
+      middle: 0.6
+      label: Cell barcodes used in result groups

--- a/regression/presets/analyze/10x-ont-sc-xcr-vdj-gemx-v3.yaml
+++ b/regression/presets/analyze/10x-ont-sc-xcr-vdj-gemx-v3.yaml
@@ -540,3 +540,34 @@ exportCloneGroups:
       args:
         - CDR3
   sortChainsBy: Auto
+qc:
+  checks:
+    - type: SuccessfullyAlignedReads
+      upper: 0.6
+      middle: 0.4
+      label: Successfully aligned reads
+    - type: UnassignedAlignments
+      upper: 0.4
+      middle: 0.2
+      label: Unassigned alignments in clonotype assembly
+    - type: AlignmentsDroppedLowQuality
+      upper: 0.4
+      middle: 0.2
+      label: Alignments dropped due to low sequence quality
+    - type: ReadsDroppedInTagRefinement
+      upper: 0.5
+      middle: 0.3
+      label: Reads dropped in tags error correction and filtering
+    - type: TagArtificialDiversityEliminated
+      tag: CELL
+      upper: 0.9
+      middle: 0.8
+      label: CELLs artificial diversity eliminated
+    - type: ReadsDroppedInTagFiltering
+      upper: 0.4
+      middle: 0.2
+      label: Reads dropped in tags filtering
+    - type: CellBarcodesWithFoundGroups
+      upper: 0.75
+      middle: 0.6
+      label: Cell barcodes used in result groups

--- a/regression/presets/analyze/10x-ont-visium-hd-3gex.yaml
+++ b/regression/presets/analyze/10x-ont-visium-hd-3gex.yaml
@@ -13923,3 +13923,25 @@ exportClones:
     - field: -topChains
   splitFilesBy: []
   groupClonesBy: []
+qc:
+  checks:
+    - type: SuccessfullyAlignedReads
+      upper: 0.6
+      middle: 0.4
+      label: Successfully aligned reads
+    - type: UnassignedAlignments
+      upper: 0.4
+      middle: 0.2
+      label: Unassigned alignments in clonotype assembly
+    - type: AlignmentsDroppedLowQuality
+      upper: 0.4
+      middle: 0.2
+      label: Alignments dropped due to low sequence quality
+    - type: ReadsDroppedInTagRefinement
+      upper: 0.5
+      middle: 0.3
+      label: Reads dropped in tags error correction and filtering
+    - type: ReadsDroppedInTagFiltering
+      upper: 0.4
+      middle: 0.2
+      label: Reads dropped in tags filtering

--- a/src/main/resources/presets/protocols/10x.yaml
+++ b/src/main/resources/presets/protocols/10x.yaml
@@ -14855,3 +14855,4 @@
   exportAlignments:
     inheritFrom: exportAlignments-single-cell-with-umi-base
 
+

--- a/src/main/resources/presets/protocols/10x.yaml
+++ b/src/main/resources/presets/protocols/10x.yaml
@@ -777,6 +777,30 @@
     - assembleCells
     - exportClones
     - exportCloneGroups
+  qc:
+    checks:
+      - type: SuccessfullyAlignedReads
+        middle: 0.4
+        upper: 0.6
+      - type: UnassignedAlignments
+        middle: 0.2
+        upper: 0.4
+      - type: AlignmentsDroppedLowQuality
+        middle: 0.2
+        upper: 0.4
+      - type: ReadsDroppedInTagRefinement
+        middle: 0.3
+        upper: 0.5
+      - type: TagArtificialDiversityEliminated
+        tag: CELL
+        middle: 0.8
+        upper: 0.9
+      - type: ReadsDroppedInTagFiltering
+        middle: 0.2
+        upper: 0.4
+      - type: CellBarcodesWithFoundGroups
+        middle: 0.6
+        upper: 0.75
   mixins:
     - type: SetTagPattern
       tagPattern: ^*cgacgctcttccgatct(CELL:N{16})(UMI:N{12})tttcttatatggg(R1:*)gtactctgcgttgataccac*
@@ -904,6 +928,30 @@
     - assembleCells
     - exportClones
     - exportCloneGroups
+  qc:
+    checks:
+      - type: SuccessfullyAlignedReads
+        middle: 0.4
+        upper: 0.6
+      - type: UnassignedAlignments
+        middle: 0.2
+        upper: 0.4
+      - type: AlignmentsDroppedLowQuality
+        middle: 0.2
+        upper: 0.4
+      - type: ReadsDroppedInTagRefinement
+        middle: 0.3
+        upper: 0.5
+      - type: TagArtificialDiversityEliminated
+        tag: CELL
+        middle: 0.8
+        upper: 0.9
+      - type: ReadsDroppedInTagFiltering
+        middle: 0.2
+        upper: 0.4
+      - type: CellBarcodesWithFoundGroups
+        middle: 0.6
+        upper: 0.75
   mixins:
     - type: SetTagPattern
       tagPattern: ^*cgacgctcttccgatct(CELL:N{16})(UMI:N{12})(R1:*)atgtactctgcgttgataccac*
@@ -7948,6 +7996,23 @@
     - assemble
     - assembleContigs
     - exportClones
+  qc:
+    checks:
+      - type: SuccessfullyAlignedReads
+        middle: 0.4
+        upper: 0.6
+      - type: UnassignedAlignments
+        middle: 0.2
+        upper: 0.4
+      - type: AlignmentsDroppedLowQuality
+        middle: 0.2
+        upper: 0.4
+      - type: ReadsDroppedInTagRefinement
+        middle: 0.3
+        upper: 0.5
+      - type: ReadsDroppedInTagFiltering
+        middle: 0.2
+        upper: 0.4
   mixins:
     - type: SetTagPattern
       tagPattern: ^*ctcttccgatctN{0:5}(UMI:N{9})N{0:3}(CELL1:gN{13:14}g)(CELL2:N{13:14}g)N{0:5}T{7:}(R1:*)


### PR DESCRIPTION
Add a `qc:` section to `10x-ont-sc-xcr-vdj-gemx-v3`, `10x-ont-sc-3gex-v4` and `10x-ont-visium-hd-3gex` presets 