### PR TITLE
Let analyze place pipeline intermediates away from the output

### DIFF
--- a/itests/case-intermediates.sh
+++ b/itests/case-intermediates.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Placement of pipeline intermediates
+
+assert() {
+  expected=$(echo -ne "${2:-}")
+  result="$(eval 2>/dev/null $1)" || true
+  result="$(sed -e 's/ *$//' -e 's/^ *//' <<<"$result")"
+  if [[ "$result" == "$expected" ]]; then
+    return
+  fi
+  result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<<"$result")"
+  [[ -z "$result" ]] && result="nothing" || result="\"$result\""
+  [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
+  echo "expected $expected got $result for" "$1"
+  exit 1
+}
+
+set -euxo pipefail
+
+R1=single_cell_vdj_t_subset_R1.fastq.gz
+R2=single_cell_vdj_t_subset_R2.fastq.gz
+
+# Default placement: every file lands next to the output
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs "$R1" "$R2" im.default
+
+assert "ls im.default.parsed.mic im.default.refined.mic im.default.alignments.vdjca | wc -l" "3"
+assert "ls im.default.assembledCells.clns im.default.qc.json | wc -l" "2"
+
+# --intermediates-dir moves the files later steps read, and only those
+rm -rf scratch
+mkdir scratch
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs --intermediates-dir ./scratch "$R1" "$R2" im.dir
+
+assert "ls im.dir.*.mic im.dir.*.vdjca im.dir.*.clna | wc -l" "0"
+assert "ls scratch/im.dir.parsed.mic scratch/im.dir.refined.mic scratch/im.dir.alignments.vdjca | wc -l" "3"
+assert "ls im.dir.assembledCells.clns im.dir.qc.txt im.dir.qc.json im.dir.align.report.txt im.dir.align.report.json | wc -l" "5"
+rm -rf scratch
+
+# --intermediates-in-temp leaves only deliverables behind, and owns the folder it used.
+# TMPDIR is set so the test asserts against a temp folder it controls.
+rm -rf tmpcheck
+mkdir tmpcheck
+TMPDIR="$(pwd)/tmpcheck" mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
+  --intermediates-in-temp --remove-intermediates "$R1" "$R2" im.temp
+
+assert "ls im.temp.*.mic im.temp.*.vdjca im.temp.*.clna | wc -l" "0"
+assert "ls im.temp.assembledCells.clns im.temp.qc.json | wc -l" "2"
+assert "find tmpcheck -mindepth 1 | wc -l" "0"
+rm -rf tmpcheck
+
+# A file given an explicit path is a deliverable and outlives --remove-intermediates
+rm -rf tmpcheck
+mkdir tmpcheck
+TMPDIR="$(pwd)/tmpcheck" mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
+  --intermediates-in-temp --remove-intermediates \
+  --output-path im.pin.parsed.mic=./im.pin.kept.mic "$R1" "$R2" im.pin
+
+assert "ls im.pin.kept.mic im.pin.assembledCells.clns | wc -l" "2"
+assert "ls im.pin.*.vdjca | wc -l" "0"
+rm -rf tmpcheck
+
+# --intermediates-dir and --remove-intermediates together: files land in the folder and are
+# freed as the run proceeds
+rm -rf scratch
+mkdir scratch
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
+  --intermediates-dir ./scratch --remove-intermediates "$R1" "$R2" im.both
+
+assert "ls im.both.assembledCells.clns | wc -l" "1"
+assert "find scratch -type f | wc -l" "0"
+rm -rf scratch
+
+# Sample-split input: the list files each step writes hold bare names, so they have to be
+# resolved against the folder that step wrote to
+rm -rf scratch
+mkdir scratch
+mixcr analyze single-cell-as-sample-split --species hs --rna \
+  --floating-left-alignment-boundary --floating-right-alignment-boundary C \
+  --assemble-clonotypes-by CDR3 --assemble-contigs-by-cells \
+  --intermediates-dir ./scratch "$R1" "$R2" im.split
+
+assert "ls im.split.sample0.clns im.split.sample1.clns im.split.sample2.clns | wc -l" "3"
+assert "ls im.split.*.vdjca | wc -l" "0"
+assert "ls scratch/im.split.sample0.alignments.vdjca scratch/im.split.sample1.alignments.vdjca scratch/im.split.sample2.alignments.vdjca | wc -l" "3"
+rm -rf scratch
+
+# A name that matches nothing the run produces is rejected rather than silently ignored. The
+# names are checked before any step runs, so this costs nothing.
+assert "mixcr analyze 10x-sc-xcr-vdj-fast --species hs --output-path im.typo.parsed.micWRONG=./x.mic $R1 $R2 im.typo 2>&1 | grep -c 'does not match any file this run produces'" "1"

--- a/regression/cli-help/align.txt
+++ b/regression/cli-help/align.txt
@@ -35,11 +35,11 @@ Usage: mixcr align --preset <preset> [--strict-sample-sheet-matching] [--trimmin
                    [--show-secondary-chain-on-export-cell-groups]
                    [--dont-show-secondary-chain-on-export-cell-groups]
                    [--export-clone-groups-sort-chains-by (Read|Molecule|Auto)] [-O <key=value>]...
-                   [--report <path>] [--json-report <path>] [--use-local-temp] [--threads <n>]
-                   [--force-overwrite] [--no-warnings] [--verbose] [--help] [-M <key=value>]...
-                   [--remove-qc-check <type> [--remove-qc-check <type>]...]... ([file_I1.fastq[.gz]
-                   [file_I2.fastq[.gz]]] file_R1.fastq[.gz] [file_R2.fastq[.gz]]|file.(fasta[.gz]
-                   |bam|sam|cram)) alignments.vdjca
+                   [--report <path>] [--json-report <path>] [--temp-dir <path>] [--use-local-temp]
+                   [--threads <n>] [--force-overwrite] [--no-warnings] [--verbose] [--help] [-M
+                   <key=value>]... [--remove-qc-check <type> [--remove-qc-check <type>]...]...
+                   ([file_I1.fastq[.gz] [file_I2.fastq[.gz]]] file_R1.fastq[.gz] [file_R2.fastq[.
+                   gz]]|file.(fasta[.gz]|bam|sam|cram)) alignments.vdjca
 Builds alignments with V,D,J and C genes for input sequencing reads.
       ([file_I1.fastq[.gz] [file_I2.fastq[.gz]]] file_R1.fastq[.gz] [file_R2.fastq[.gz]]|file.(fasta
         [.gz]|bam|sam|cram))
@@ -165,6 +165,13 @@ Builds alignments with V,D,J and C genes for input sequencing reads.
   -r, --report <path>        Report file (human readable version, see `-j / --json-report` for
                                machine readable report).
   -j, --json-report <path>   JSON formatted report file.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -t, --threads <n>          Processing threads
   -f, --force-overwrite      Force overwrite of output file(s).

--- a/regression/cli-help/analyze.txt
+++ b/regression/cli-help/analyze.txt
@@ -31,6 +31,8 @@ Usage: mixcr analyze [--reference-for-cram genome.fasta[.gz]] [--lenient-bam-val
                      [--dont-show-secondary-chain-on-export-cell-groups]
                      [--export-clone-groups-sort-chains-by (Read|Molecule|Auto)] [--no-reports]
                      [--no-json-reports] [--output-not-used-reads] [--strict-sample-sheet-matching]
+                     [--intermediates-dir <path>] [--intermediates-in-temp]
+                     [--remove-intermediates] [--output-path <name=path>]... [--temp-dir <path>]
                      [--use-local-temp] [--threads <n>] [--force-overwrite] [--no-warnings]
                      [--verbose] [--help] [-M <key=value>]... [--remove-qc-check <type>
                      [--remove-qc-check <type>]...]... <preset> ([file_I1.fastq[.gz] [file_I2.fastq
@@ -64,6 +66,41 @@ Run full MiXCR pipeline for specific input.
                              Perform strict matching against input sample sheet (one substitution
                                will be allowed by default).
                              This option only valid if input file is *.tsv sample sheet.
+      --intermediates-dir <path>
+                             Write intermediate files to the specified folder instead of next to
+                               the output files, creating it if needed. Intermediates are the step
+                               data outputs that later steps read: the .mic and .vdjca files, and
+                               any .clns/.clna the pipeline produces before the last one. Reports,
+                               QC and exports are unaffected and stay with the output files.
+                               Mutually exclusive with --intermediates-in-temp.
+      --intermediates-in-temp
+                             Write intermediate files to a folder MiXCR creates inside the system
+                               temp folder and removes when the run exits, including after a failed
+                               step but not if the process is killed outright. The system temp
+                               folder must have room for them; in a container that is the
+                               container's own /tmp. Use --intermediates-dir to place them
+                               somewhere you choose. Mutually exclusive with --intermediates-dir.
+      --remove-intermediates Delete each intermediate file as soon as the last step that reads it
+                               has finished, so the run holds only what it still needs rather than
+                               every file it has produced. A file given an explicit --output-path
+                               is a deliverable and is never deleted. Recovering from a failed step
+                               means re-running from the input files.
+      --output-path <name=path>
+                             Write one produced file to an explicit path, overriding every other
+                               placement option and making that file a deliverable. The name is the
+                               file name the step produces, as printed with the step's command
+                               while the run executes, e.g. --output-path result.vdjca=/data/result.
+                               vdjca. Repeat to pin several files. For multi-sample input use the
+                               name produced before the input is split by sample; with several
+                               samples the folder of the path is used and each sample keeps its own
+                               file name.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -t, --threads <n>          Processing threads
   -f, --force-overwrite      Force overwrite of output file(s).

--- a/regression/cli-help/assemble.txt
+++ b/regression/cli-help/assemble.txt
@@ -2,8 +2,9 @@ Usage: mixcr assemble [--write-alignments] [--cell-level] [--sort-by-sequence]
                       [--dont-infer-threshold] [--high-compression] [--assemble-clonotypes-by
                       <gene_features>] [--split-clones-by <gene_type>]... [--dont-split-clones-by
                       <gene_type>]... [-O <key=value>]... [-P <key=value>]... [--report <path>]
-                      [--json-report <path>] [--use-local-temp] [--force-overwrite] [--no-warnings]
-                      [--verbose] [--help] alignments.vdjca clones.(clns|clna)
+                      [--json-report <path>] [--temp-dir <path>] [--use-local-temp]
+                      [--force-overwrite] [--no-warnings] [--verbose] [--help] alignments.vdjca
+                      clones.(clns|clna)
 Assemble clones.
       alignments.vdjca       Path to input file with alignments.
       clones.(clns|clna)     Path where to write assembled clones.
@@ -40,6 +41,13 @@ Assemble clones.
   -r, --report <path>        Report file (human readable version, see `-j / --json-report` for
                                machine readable report).
   -j, --json-report <path>   JSON formatted report file.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -f, --force-overwrite      Force overwrite of output file(s).
       -nw, --no-warnings     Suppress all warning messages.

--- a/regression/cli-help/assembleCells.txt
+++ b/regression/cli-help/assembleCells.txt
@@ -1,6 +1,6 @@
-Usage: mixcr assembleCells [-O <key=value>]... [--report <path>] [--json-report <path>]
-                           [--use-local-temp] [--force-overwrite] [--no-warnings] [--verbose]
-                           [--help] clones.(clns|clna) grouped.(clns|clna)
+Usage: mixcr assembleCells [-O <key=value>]... [--report <path>] [--json-report <path>] [--temp-dir
+                           <path>] [--use-local-temp] [--force-overwrite] [--no-warnings]
+                           [--verbose] [--help] clones.(clns|clna) grouped.(clns|clna)
 Group clones by cells. Required data with cell tags. All clones should be fully covered by the same
 feature.
       clones.(clns|clna)     Path to input file.
@@ -9,6 +9,13 @@ feature.
   -r, --report <path>        Report file (human readable version, see `-j / --json-report` for
                                machine readable report).
   -j, --json-report <path>   JSON formatted report file.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -f, --force-overwrite      Force overwrite of output file(s).
       -nw, --no-warnings     Suppress all warning messages.

--- a/regression/cli-help/exportShmTreesWithNodes.txt
+++ b/regression/cli-help/exportShmTreesWithNodes.txt
@@ -100,11 +100,11 @@ Usage: mixcr exportShmTreesWithNodes [--split-by-tags (Molecule|Cell|Sample)] [-
                                      [<gene_feature>]]... [-biochemicalProperty <gene_feature>
                                      <property> [(germline|mrca|parent)]]...
                                      [-baseBiochemicalProperties <gene_feature>
-                                     [(germline|mrca|parent)]]... [--use-local-temp]
-                                     [--force-overwrite] [--no-warnings] [--verbose] [--help]
-                                     [[--filter-in-feature <gene_feature>] [--pattern-max-errors
-                                     <n>] (--filter-aa-pattern <pattern> | --filter-nt-pattern
-                                     <pattern>)] trees.shmt [trees.tsv]
+                                     [(germline|mrca|parent)]]... [--temp-dir <path>]
+                                     [--use-local-temp] [--force-overwrite] [--no-warnings]
+                                     [--verbose] [--help] [[--filter-in-feature <gene_feature>]
+                                     [--pattern-max-errors <n>] (--filter-aa-pattern <pattern> |
+                                     --filter-nt-pattern <pattern>)] trees.shmt [trees.tsv]
 Export SHMTree as a table with a row for every clone or reconstructed node for each root (only one
 root if no single cell data)
       trees.shmt             Input file produced by 'findShmTrees' command.
@@ -124,6 +124,13 @@ root if no single cell data)
                              Specify preset file of export fields
       --no-header            Don't print first header line, print only data
       --not-covered-as-empty Export not covered regions as empty text.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -f, --force-overwrite      Force overwrite of output file(s).
       -nw, --no-warnings     Suppress all warning messages.

--- a/regression/cli-help/findAlleles.txt
+++ b/regression/cli-help/findAlleles.txt
@@ -1,8 +1,8 @@
 Usage: mixcr findAlleles [--export-library <path.(json|fasta)>]... [--export-alleles-mutations
                          <path.(t|c)sv>] [--result-library-name <name>]
                          [--dont-remove-unused-genes] [-O <key=value>]... [--report <path>]
-                         [--json-report <path>] [--use-local-temp] [--threads <n>]
-                         [--force-overwrite] [--no-warnings] [--verbose] [--help]
+                         [--json-report <path>] [--temp-dir <path>] [--use-local-temp] [--threads
+                         <n>] [--force-overwrite] [--no-warnings] [--verbose] [--help]
                          (--output-template <template.clns> | --no-clns-output) (input_file.
                          (clns|clna)|directory)...
 Find allele variants in clnx.
@@ -88,6 +88,13 @@ of V and J genes and the same features to align.
   -r, --report <path>        Report file (human readable version, see `-j / --json-report` for
                                machine readable report).
   -j, --json-report <path>   JSON formatted report file.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -t, --threads <n>          Processing threads
   -f, --force-overwrite      Force overwrite of output file(s).

--- a/regression/cli-help/findShmTrees.txt
+++ b/regression/cli-help/findShmTrees.txt
@@ -1,9 +1,10 @@
 Usage: mixcr findShmTrees [--v-gene-names <gene_name>]... [--j-gene-names <gene_name>]...
                           [--cdr3-lengths <n>]... [--min-count <n>] [--productive-only]
                           [--dont-combine-tree-by-cells] [--alleles-search-could-be-skipped] [-O
-                          <key=value>]... [--report <path>] [--json-report <path>]
-                          [--use-local-temp] [--threads <n>] [--force-overwrite] [--no-warnings]
-                          [--verbose] [--help] (input_file.clns|directory)... output_file.shmt
+                          <key=value>]... [--report <path>] [--json-report <path>] [--temp-dir
+                          <path>] [--use-local-temp] [--threads <n>] [--force-overwrite]
+                          [--no-warnings] [--verbose] [--help] (input_file.clns|directory)...
+                          output_file.shmt
 Builds SHM trees.
 All inputs must be fully covered by the same feature, have the same library produced by
 `findAlleles`, the same scoring of V and J genes and the same features to align.
@@ -36,6 +37,13 @@ All inputs must be fully covered by the same feature, have the same library prod
   -r, --report <path>        Report file (human readable version, see `-j / --json-report` for
                                machine readable report).
   -j, --json-report <path>   JSON formatted report file.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -t, --threads <n>          Processing threads
   -f, --force-overwrite      Force overwrite of output file(s).

--- a/regression/cli-help/refineTagsAndSort.txt
+++ b/regression/cli-help/refineTagsAndSort.txt
@@ -4,8 +4,9 @@ Usage: mixcr refineTagsAndSort [--power <d>] [--substitution-rate <d>] [--indel-
                                <key=value>] [--reset-whitelist <tag_name>]
                                [--dont-correct-tag-with-name <tag_name>] [--dont-correct-tag-type
                                (Molecule|Cell|Sample)] [--report <path>] [--json-report <path>]
-                               [--use-local-temp] [--force-overwrite] [--no-warnings] [--verbose]
-                               [--help] alignments.vdjca alignments.corrected.vdjca
+                               [--temp-dir <path>] [--use-local-temp] [--force-overwrite]
+                               [--no-warnings] [--verbose] [--help] alignments.vdjca alignments.
+                               corrected.vdjca
 Applies error correction algorithm for tag sequences and sorts resulting file by tags.
       alignments.vdjca       Path to input alignments
       alignments.corrected.vdjca
@@ -49,6 +50,13 @@ Applies error correction algorithm for tag sequences and sorts resulting file by
   -r, --report <path>        Report file (human readable version, see `-j / --json-report` for
                                machine readable report).
   -j, --json-report <path>   JSON formatted report file.
+      --temp-dir <path>      Put temporary files, such as sort spills, in the specified folder,
+                               creating it if needed. In analyze, defaults to the intermediates
+                               location when those are relocated, and to the system temp folder
+                               otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                               delegates to mitool do not take a folder: their scratch data sits
+                               next to their own output when intermediates are relocated or
+                               --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -f, --force-overwrite      Force overwrite of output file(s).
       -nw, --no-warnings     Suppress all warning messages.

--- a/regression/cli-help/slice.txt
+++ b/regression/cli-help/slice.txt
@@ -1,6 +1,6 @@
-Usage: mixcr slice [--reassign-ids] [--use-local-temp] [--force-overwrite] [--no-warnings]
-                   [--verbose] [--help] (-i <id> [-i <id>]... | --ids-file <path>) data.
-                   (vdjca|clns|clna|shmt) data_sliced.(vdjca|clns|clna|shmt)
+Usage: mixcr slice [--reassign-ids] [--temp-dir <path>] [--use-local-temp] [--force-overwrite]
+                   [--no-warnings] [--verbose] [--help] (-i <id> [-i <id>]... | --ids-file <path>)
+                   data.(vdjca|clns|clna|shmt) data_sliced.(vdjca|clns|clna|shmt)
 Slice vdjca|clns|clna|shmt file.
       data.(vdjca|clns|clna|shmt)
                            Input data to filter by ids
@@ -12,6 +12,13 @@ Slice vdjca|clns|clna|shmt file.
                              (for .shmt) ids to export.
                            Every id on separate line
       --reassign-ids       Reassigned ids with a new sequence from 0
+      --temp-dir <path>    Put temporary files, such as sort spills, in the specified folder,
+                             creating it if needed. In analyze, defaults to the intermediates
+                             location when those are relocated, and to the system temp folder
+                             otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                             delegates to mitool do not take a folder: their scratch data sits next
+                             to their own output when intermediates are relocated or
+                             --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp     Put temporary files in the same folder as the output files.
   -f, --force-overwrite    Force overwrite of output file(s).
       -nw, --no-warnings   Suppress all warning messages.

--- a/regression/cli-help/sortAlignments.txt
+++ b/regression/cli-help/sortAlignments.txt
@@ -1,9 +1,17 @@
-Usage: mixcr sortAlignments [--use-local-temp] [--force-overwrite] [--no-warnings] [--verbose]
-                            [--help] alignments.vdjca alignments.sorted.vdjca
+Usage: mixcr sortAlignments [--temp-dir <path>] [--use-local-temp] [--force-overwrite]
+                            [--no-warnings] [--verbose] [--help] alignments.vdjca alignments.sorted.
+                            vdjca
 Sort alignments in vdjca file by read id.
       alignments.vdjca
       alignments.sorted.vdjca
 
+      --temp-dir <path>    Put temporary files, such as sort spills, in the specified folder,
+                             creating it if needed. In analyze, defaults to the intermediates
+                             location when those are relocated, and to the system temp folder
+                             otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                             delegates to mitool do not take a folder: their scratch data sits next
+                             to their own output when intermediates are relocated or
+                             --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp     Put temporary files in the same folder as the output files.
   -f, --force-overwrite    Force overwrite of output file(s).
       -nw, --no-warnings   Suppress all warning messages.

--- a/regression/cli-help/sortClones.txt
+++ b/regression/cli-help/sortClones.txt
@@ -1,6 +1,6 @@
-Usage: mixcr sortClones [--by-feature <gene_feature>]... [--by-gene <gene_type>]...
-                        [--use-local-temp] [--force-overwrite] [--no-warnings] [--verbose] [--help]
-                        clones.(clns|clna) clones.sorted.(clns|clna)
+Usage: mixcr sortClones [--by-feature <gene_feature>]... [--by-gene <gene_type>]... [--temp-dir
+                        <path>] [--use-local-temp] [--force-overwrite] [--no-warnings] [--verbose]
+                        [--help] clones.(clns|clna) clones.sorted.(clns|clna)
 Sort clones by sequence. Clones in the output file will be sorted by clonal sequence, which allows
 to build overlaps between clonesets.
       clones.(clns|clna)
@@ -11,6 +11,13 @@ to build overlaps between clonesets.
       --by-gene <gene_type>
                            Sort by specified genes. This sorting will be applied after sorting by
                              `--feature`. By default `V` and 'J' will be used
+      --temp-dir <path>    Put temporary files, such as sort spills, in the specified folder,
+                             creating it if needed. In analyze, defaults to the intermediates
+                             location when those are relocated, and to the system temp folder
+                             otherwise. Takes precedence over --use-local-temp. Steps that MiXCR
+                             delegates to mitool do not take a folder: their scratch data sits next
+                             to their own output when intermediates are relocated or
+                             --use-local-temp is given, and in the system temp folder otherwise.
       --use-local-temp     Put temporary files in the same folder as the output files.
   -f, --force-overwrite    Force overwrite of output file(s).
       -nw, --no-warnings   Suppress all warning messages.

--- a/regression/reports/baseSingleCell.raw.yaml
+++ b/regression/reports/baseSingleCell.raw.yaml
@@ -919,7 +919,7 @@ mitool-parse:
             costDistributions:
               "0": 46879
   trimmerReport: null
-  commandLine: parse --report baseSingleCell.raw.parse.report.txt --preset local:MiTool.preset
+  commandLine: parse --report baseSingleCell.raw.parse.report.txt --preset local:baseSingleCell.raw.MiTool.preset
     --save-output-file-names baseSingleCell.raw.parse.list.tsv single_cell_vdj_t_subset_R1.fastq.gz
     single_cell_vdj_t_subset_R2.fastq.gz baseSingleCell.raw.parsed.mic
   inputFiles:

--- a/regression/reports/baseSingleCell.vdjcontigs.yaml
+++ b/regression/reports/baseSingleCell.vdjcontigs.yaml
@@ -922,7 +922,7 @@ mitool-parse:
               "0": 46879
   trimmerReport: null
   commandLine: parse --report baseSingleCell.vdjcontigs.parse.report.txt --preset
-    local:MiTool.preset --save-output-file-names baseSingleCell.vdjcontigs.parse.list.tsv
+    local:baseSingleCell.vdjcontigs.MiTool.preset --save-output-file-names baseSingleCell.vdjcontigs.parse.list.tsv
     single_cell_vdj_t_subset_R1.fastq.gz single_cell_vdj_t_subset_R2.fastq.gz baseSingleCell.vdjcontigs.parsed.mic
   inputFiles:
     - single_cell_vdj_t_subset_R1.fastq.gz

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAlign.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAlign.kt
@@ -115,7 +115,6 @@ import com.milaboratory.util.PathPatternExpandException
 import com.milaboratory.util.ReportHelper
 import com.milaboratory.util.ReportUtil
 import com.milaboratory.util.SmartProgressReporter
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.limit
 import com.milaboratory.util.parseAndRunAndCorrelateFSPattern
 import com.milaboratory.util.use
@@ -734,12 +733,8 @@ object CommandAlign {
         description = ["Builds alignments with V,D,J and C genes for input sequencing reads."]
     )
     class Cmd : CmdBase() {
-        @Option(
-            description = ["Put temporary files in the same folder as the output files."],
-            names = ["--use-local-temp"],
-            order = OptionsOrder.localTemp
-        )
-        var useLocalTemp = false
+        @Mixin
+        lateinit var useLocalTemp: UseLocalTempOption
 
         @Option(
             description = ["Analysis preset. Sets key parameters of this and all downstream analysis steps. " +
@@ -916,7 +911,7 @@ object CommandAlign {
         private var outputFileList: Path? = null
 
         private val tempDest by lazy {
-            TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp)
+            useLocalTemp.tempDestination(outputFile, "")
         }
 
 

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAnalyze.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAnalyze.kt
@@ -13,6 +13,7 @@ package com.milaboratory.mixcr.cli
 
 import com.milaboratory.app.InputFileType
 import com.milaboratory.app.ValidationException
+import com.milaboratory.app.logger
 import com.milaboratory.app.matches
 import com.milaboratory.cli.MultiSampleRun.SAVE_OUTPUT_FILE_NAMES_OPTION
 import com.milaboratory.cli.MultiSampleRun.listToSampleName
@@ -35,6 +36,7 @@ import com.milaboratory.mixcr.presets.MiXCRParamsBundle
 import com.milaboratory.mixcr.presets.MiXCRParamsSpec
 import com.milaboratory.mixcr.presets.MiXCRPipeline
 import com.milaboratory.util.K_YAML_OM
+import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.PathPatternExpandException
 import com.milaboratory.util.parseAndRunAndCorrelateFSPattern
 import picocli.CommandLine.ArgGroup
@@ -46,12 +48,14 @@ import picocli.CommandLine.Model.PositionalParamSpec
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 import java.io.File
+import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
 import kotlin.io.path.name
 import kotlin.io.path.readLines
 import kotlin.system.exitProcess
@@ -225,6 +229,53 @@ object CommandAnalyze {
         private var dryRun: Boolean = false
 
         @Option(
+            description = ["Write intermediate files to the specified folder instead of next to the " +
+                    "output files, creating it if needed. Intermediates are the step data outputs that " +
+                    "later steps read: the .mic and .vdjca files, and any .clns/.clna the pipeline " +
+                    "produces before the last one. Reports, QC and exports are unaffected and stay with " +
+                    "the output files. Mutually exclusive with --intermediates-in-temp."],
+            names = ["--intermediates-dir"],
+            paramLabel = "<path>",
+            order = OptionsOrder.intermediates
+        )
+        private var intermediatesDir: Path? = null
+
+        @Option(
+            description = ["Write intermediate files to a folder MiXCR creates inside the system temp " +
+                    "folder and removes when the run exits, including after a failed step but not if the " +
+                    "process is killed outright. The system temp folder must have room for them; in a " +
+                    "container that is the container's own /tmp. Use --intermediates-dir to place them " +
+                    "somewhere you choose. Mutually exclusive with --intermediates-dir."],
+            names = ["--intermediates-in-temp"],
+            order = OptionsOrder.intermediates + 1
+        )
+        private var intermediatesInTemp: Boolean = false
+
+        @Option(
+            description = ["Delete each intermediate file as soon as the last step that reads it has " +
+                    "finished, so the run holds only what it still needs rather than every file it has " +
+                    "produced. A file given an explicit --output-path is a deliverable and is never " +
+                    "deleted. Recovering from a failed step means re-running from the input files."],
+            names = ["--remove-intermediates"],
+            order = OptionsOrder.intermediates + 2
+        )
+        private var removeIntermediates: Boolean = false
+
+        @Option(
+            description = ["Write one produced file to an explicit path, overriding every other " +
+                    "placement option and making that file a deliverable. The name is the file name the " +
+                    "step produces, as printed with the step's command while the run executes, e.g. " +
+                    "--output-path result.vdjca=/data/result.vdjca. Repeat to pin several files. For " +
+                    "multi-sample input use the name produced before the input is split by sample; with " +
+                    "several samples the folder of the path is used and each sample keeps its own file " +
+                    "name."],
+            names = ["--output-path"],
+            paramLabel = "<name=path>",
+            order = OptionsOrder.intermediates + 3
+        )
+        private var outputPaths: Map<String, Path> = mutableMapOf()
+
+        @Option(
             description = ["Don't output report files for each of the steps"],
             names = ["--no-reports"],
             order = OptionsOrder.report + 100
@@ -325,6 +376,14 @@ object CommandAnalyze {
 
             if (strictMatching && inputSampleSheet == null)
                 throw ValidationException("$STRICT_SAMPLE_NAME_MATCHING_OPTION is valid only with sample sheet input, i.e. a *.tsv file.")
+
+            if (intermediatesDir != null && intermediatesInTemp)
+                throw ValidationException("--intermediates-dir and --intermediates-in-temp are mutually exclusive.")
+
+            intermediatesDir?.let { dir ->
+                if (dir.exists() && !dir.isDirectory())
+                    throw ValidationException("--intermediates-dir is not a folder: $dir")
+            }
         }
 
         override fun run0() {
@@ -355,10 +414,53 @@ object CommandAnalyze {
             if (pipeline.first() !in arrayOf(align, parse))
                 throw ValidationException("Pipeline must stat from the `align` or `parse` action.")
 
+            // Folder for the files later steps consume; null keeps them next to the output files
+            val intermediatesFolder: Path? = when {
+                intermediatesInTemp -> TempFileManager.newTempDir().toPath()
+                else -> intermediatesDir?.also { if (!it.exists()) it.createDirectories() }
+            }
+
+            // Exports and qc read a production step's output, they don't extend the chain, so the
+            // last production step is the one whose output nothing else consumes
+            val terminalStep = pipeline
+                .filterNot { it is AnalyzeCommandDescriptor.ExportCommandDescriptor<*> }
+                .filterNot { it == AnalyzeCommandDescriptor.qc }
+                .last()
+
+            // Every name --output-path can address, taken before the input is split by sample. A
+            // name that matches nothing would otherwise be a silent no-op, and under
+            // --remove-intermediates the file the caller meant to keep would be deleted instead.
+            val producibleNames = if (outputPaths.isEmpty()) emptySet() else buildSet {
+                val qcStep = AnalyzeCommandDescriptor.qc
+                    .takeIf { bundle.qc?.checks?.isNotEmpty() == true && it !in pipeline }
+                (pipeline + listOfNotNull(qcStep)).forEach { cmd ->
+                    val rounds = (cmd as? AllowedMultipleRounds)?.roundsCount(bundle) ?: 1
+                    repeat(rounds) { round ->
+                        val outputName = cmd.outputName(outputNamePrefix, "", bundle, round)
+                        if (cmd == AnalyzeCommandDescriptor.qc) {
+                            val base = outputName.substring(0, outputName.lastIndexOf('.'))
+                            add("$base.txt")
+                            add("$base.json")
+                        } else
+                            add(outputName)
+                        cmd.textReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
+                        cmd.jsonReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
+                    }
+                }
+            }
+            val unknownPins = outputPaths.keys - producibleNames
+            if (unknownPins.isNotEmpty())
+                throw ValidationException(
+                    "--output-path does not match any file this run produces: " +
+                            "${unknownPins.sorted().joinToString(", ")}. " +
+                            "Available: ${producibleNames.sorted().joinToString(", ")}"
+                )
+
             val planBuilder = PlanBuilder(
                 bundle, outputFolder, outputNamePrefix,
                 !noReports, !noJsonReports,
-                inputTemplates, threadsOption, useLocalTemp, forceOverwrite
+                inputTemplates, threadsOption, useLocalTemp, forceOverwrite,
+                intermediatesFolder, outputPaths, removeIntermediates, terminalStep
             )
 
             if (pipeline.first() == parse) {
@@ -383,19 +485,26 @@ object CommandAnalyze {
                         addNotParsed = false
                     )
                 }
-                val mitoolPresetPath = Paths.get("MiTool.preset.yaml").toFile()
-                mitoolPresetPath.deleteOnExit()
-                K_YAML_OM.writeValue(mitoolPresetPath, mitoolPreset)
+                // mitool resolves a local: name against its own search path, which includes the
+                // working directory, and Path.resolve returns an absolute argument unchanged, so
+                // this path works either relative or absolute. It is passed on exactly as given:
+                // resolving it against the working directory would put that directory into the
+                // command line recorded in every output header, and two runs of the same analysis
+                // from different folders would stop producing identical files.
+                val mitoolPresetPath = (intermediatesFolder ?: outputFolder)
+                    .resolve("${outputNamePrefix.dotAfterIfNotBlank()}MiTool.preset.yaml")
+                mitoolPresetPath.toFile().deleteOnExit()
+                K_YAML_OM.writeValue(mitoolPresetPath.toFile(), mitoolPreset)
 
                 // Adding an option to save output files by parse
-                val sampleFileList = outputFolder
+                val sampleFileList = (intermediatesFolder ?: outputFolder)
                     .resolve("${outputNamePrefix.dotAfterIfNotBlank()}parse.list.tsv")
                     .also { it.deleteIfExists() }
                     .toFile().also { it.deleteOnExit() }
 
                 planBuilder.addStep(parse) { _, _, _ ->
                     buildList {
-                        this += listOf("--preset", "local:${mitoolPresetPath.name.removeSuffix(".yaml")}")
+                        this += listOf("--preset", "local:${mitoolPresetPath.toString().removeSuffix(".yaml")}")
                         this += listOf(SAVE_OUTPUT_FILE_NAMES_OPTION, sampleFileList.toString())
                         this += pathsForNotAligned.argsOfNotParsedForMiToolParse()
                     }
@@ -403,7 +512,7 @@ object CommandAnalyze {
 
                 planBuilder.executeSteps(dryRun)
                 // Taking into account that there are multiple outputs from the mitool parse command.
-                planBuilder.setActualOutputs(sampleFileList.toPath())
+                planBuilder.setActualOutputs(parse, sampleFileList.toPath())
 
                 pipeline
                     .drop(1) // without parse
@@ -425,7 +534,7 @@ object CommandAnalyze {
                     this += listOf("--preset", presetName)
                     if (bundle.align!!.splitBySample && !dryRun) {
                         // Adding an option to save output files by align
-                        val sampleFileList = outputFolder
+                        val sampleFileList = (intermediatesFolder ?: outputFolder)
                             .resolve("${outputNamePrefix.dotAfterIfNotBlank()}${sampleName.dotAfterIfNotBlank()}align.list.tsv")
                             .also { it.deleteIfExists() }
                             .toFile().also { it.deleteOnExit() }
@@ -454,7 +563,7 @@ object CommandAnalyze {
             // Taking into account that there are multiple outputs from the align command.
             // Even so, mitool could split into several files and then align could split each too
             if (sampleFileListFiles.isNotEmpty()) {
-                planBuilder.setActualOutputs(sampleFileListFiles)
+                planBuilder.setActualOutputs(align, sampleFileListFiles)
             }
 
             // Adding all steps with calculations
@@ -526,24 +635,85 @@ object CommandAnalyze {
             initialInputs: List<Path>,
             private val threadsOption: ThreadsOption,
             private val useLocalTemp: UseLocalTempOption,
-            private val forceOverride: Boolean
+            private val forceOverride: Boolean,
+            private val intermediatesFolder: Path?,
+            private val outputPaths: Map<String, Path>,
+            private val removeIntermediates: Boolean,
+            private val terminalStep: AnalyzeCommandDescriptor<*, *>
         ) {
             private val executionPlan = mutableListOf<ExecutionStep>()
             private var nextInputs: List<InputFileSet> = listOf(InputFileSet("", initialInputs.map { it.toString() }))
             private val outputsForCommands = mutableListOf<Pair<AnalyzeCommandDescriptor<*, *>, List<InputFileSet>>>()
 
-            fun setActualOutputs(outputFilesList: Path) {
-                setActualOutputs(mapOf("" to outputFilesList))
+            /** Produced files that are safe to delete once no planned step reads them any more */
+            private val removableIntermediates = mutableSetOf<String>()
+
+            /** Where each command put its outputs, for resolving the file names it reported */
+            private val placements = mutableMapOf<AnalyzeCommandDescriptor<*, *>, StepPlacement>()
+
+            private class StepPlacement(val folder: Path, val removable: Boolean)
+
+            /**
+             * Output of every step but the last production one is read further down the pipeline. Rounds of
+             * one command chain the same way, so only the last round of the last command is a deliverable.
+             */
+            private fun isIntermediate(cmd: AnalyzeCommandDescriptor<*, *>, round: Int, roundsCount: Int) =
+                cmd != terminalStep || round != roundsCount - 1
+
+            /**
+             * Path pinned by --output-path, if any.
+             *
+             * Pins are keyed by [seedName], the name the step produces before the input is split by
+             * sample, so one key addresses a step rather than one sample of it. A single path cannot
+             * hold several samples, so with more than one it contributes its folder and each sample
+             * keeps its own name.
+             */
+            private fun pinned(actualName: String, seedName: String, singleSample: Boolean): Path? =
+                outputPaths[seedName]?.let { pinned ->
+                    if (singleSample) pinned else (pinned.parent ?: Path("")).resolve(actualName)
+                }
+
+            /** Files that stay with the output files, unless pinned */
+            private fun deliverable(actualName: String, seedName: String, singleSample: Boolean): Path =
+                pinned(actualName, seedName, singleSample) ?: outputFolder.resolve(actualName)
+
+            /**
+             * The precedence chain: an explicit --output-path wins, then the intermediates folder for
+             * anything read further down the pipeline, then the positional output prefix.
+             */
+            private fun resolveOutput(
+                actualName: String,
+                seedName: String,
+                intermediate: Boolean,
+                singleSample: Boolean
+            ): Path {
+                pinned(actualName, seedName, singleSample)?.let { return it }
+                val folder = if (intermediate) intermediatesFolder ?: outputFolder else outputFolder
+                return folder.resolve(actualName)
             }
 
-            fun setActualOutputs(outputFilesList: Map<String, Path>) {
+            fun setActualOutputs(cmd: AnalyzeCommandDescriptor<*, *>, outputFilesList: Path) {
+                setActualOutputs(cmd, mapOf("" to outputFilesList))
+            }
+
+            /**
+             * Replaces the planned output of [cmd] with the files it actually wrote, one per sample.
+             *
+             * The list files hold bare file names, written as siblings of the output the step was given,
+             * so they resolve against the folder that step wrote to rather than the output prefix.
+             */
+            fun setActualOutputs(cmd: AnalyzeCommandDescriptor<*, *>, outputFilesList: Map<String, Path>) {
+                val placement = placements.getValue(cmd)
                 nextInputs = outputFilesList.flatMap { (prefix, file) ->
                     val withoutHeader = file.readLines().drop(1)
                     withoutHeader.map { it.split("\t") }.map { line ->
                         val sampleName = listToSampleName(line.drop(2))
+                        val output = placement.folder.resolve(line[0]).toString()
+                        if (placement.removable)
+                            removableIntermediates += output
                         InputFileSet(
                             "${prefix.dotAfterIfNotBlank()}$sampleName",
-                            listOf(outputFolder.resolve(line[0]).toString())
+                            listOf(output)
                         )
                     }
                 }
@@ -554,8 +724,20 @@ object CommandAnalyze {
                     // Printing commands that would have been executed
                     executionPlan.forEach { pe -> println(pe) }
                 } else {
+                    // A file is freed after the last step of this batch that reads it, so one that an
+                    // export or QC step still reads outlives the production step that consumed it.
+                    // Readers of a given file are always planned in the same batch as each other.
+                    val lastReaderOf = mutableMapOf<String, Int>()
+                    if (removeIntermediates)
+                        executionPlan.forEachIndexed { index, step ->
+                            step.inputs
+                                .filter { it in removableIntermediates }
+                                .forEach { lastReaderOf[it] = index }
+                        }
+                    val freeAfter = lastReaderOf.entries.groupBy({ it.value }, { it.key })
+
                     // Executing the plan
-                    for (executionStep in executionPlan) {
+                    executionPlan.forEachIndexed { index, executionStep ->
                         println("\n" + Util.surround("mixcr ${executionStep.command}", ">", "<"))
                         println("Running:")
                         println(executionStep)
@@ -564,6 +746,13 @@ object CommandAnalyze {
                         if (exitCode != 0)
                         // Terminating execution if one of the steps resulted in error
                             exitProcess(exitCode)
+                        freeAfter[index]?.forEach { file ->
+                            try {
+                                Path(file).deleteIfExists()
+                            } catch (e: IOException) {
+                                logger.warn("Can't remove intermediate file $file: ${e.message}")
+                            }
+                        }
                     }
                 }
 
@@ -575,6 +764,7 @@ object CommandAnalyze {
 
             fun addQC() {
                 val inputsForQc = outputsForCommands.findLast { (command) -> command.outputSupportsQc }!!.second
+                val singleSample = inputsForQc.size == 1
                 for (input in inputsForQc) {
                     check(input.fileNames.size == 1)
                     val round = 0
@@ -590,10 +780,21 @@ object CommandAnalyze {
                         arguments,
                         emptyList(),
                         listOf(input.fileNames.first()),
-                        listOf(
-                            outputFolder.resolve(outputName.removeExtension() + ".txt").toString(),
-                            outputFolder.resolve(outputName.removeExtension() + ".json").toString()
-                        )
+                        run {
+                            val seed = cmd.outputName(outputNamePrefix, "", paramsBundle, round)
+                            listOf(
+                                deliverable(
+                                    outputName.removeExtension() + ".txt",
+                                    seed.removeExtension() + ".txt",
+                                    singleSample
+                                ).toString(),
+                                deliverable(
+                                    outputName.removeExtension() + ".json",
+                                    seed.removeExtension() + ".json",
+                                    singleSample
+                                ).toString()
+                            )
+                        }
                     )
                 }
             }
@@ -602,6 +803,7 @@ object CommandAnalyze {
                 val runAfter = cmd.runAfterLastOf()
                 // if there is nothing to run on (production command is removed), don't run it
                 val (_, inputsForExport) = outputsForCommands.findLast { (cmd) -> cmd in runAfter } ?: return
+                val singleSample = inputsForExport.size == 1
                 for (input in inputsForExport) {
                     check(input.fileNames.size == 1)
                     val round = 0
@@ -617,7 +819,13 @@ object CommandAnalyze {
                         arguments,
                         emptyList(),
                         listOf(input.fileNames.first()),
-                        listOf(outputFolder.resolve(outputName).toString())
+                        listOf(
+                            deliverable(
+                                outputName,
+                                cmd.outputName(outputNamePrefix, "", paramsBundle, round),
+                                singleSample
+                            ).toString()
+                        )
                     )
                 }
             }
@@ -629,6 +837,9 @@ object CommandAnalyze {
                 val roundsCount = (cmd as? AllowedMultipleRounds)?.roundsCount(paramsBundle) ?: 1
 
                 repeat(roundsCount) { round ->
+                    val intermediate = isIntermediate(cmd, round, roundsCount)
+                    val seedName = cmd.outputName(outputNamePrefix, "", paramsBundle, round)
+                    val singleSample = nextInputs.size == 1
 
                     val nextInputsBuilder = mutableListOf<InputFileSet>()
 
@@ -638,26 +849,53 @@ object CommandAnalyze {
                         if (forceOverride && cmd !is MiToolCommandDelegationDescriptor<*, *>)
                             arguments += "-f"
 
+                        // Reports are deliverables even for a step whose data output is an intermediate,
+                        // so they stay with the output files while the data output moves
                         if (outputReports)
                             cmd.textReportName(outputNamePrefix, inputs.sampleName, paramsBundle, round)?.let {
-                                arguments += listOf("--report", outputFolder.resolve(it).toString())
+                                val seed = cmd.textReportName(outputNamePrefix, "", paramsBundle, round)!!
+                                arguments += listOf("--report", deliverable(it, seed, singleSample).toString())
                             }
 
                         if (outputJsonReports)
                             cmd.jsonReportName(outputNamePrefix, inputs.sampleName, paramsBundle, round)?.let {
-                                arguments += listOf("--json-report", outputFolder.resolve(it).toString())
+                                val seed = cmd.jsonReportName(outputNamePrefix, "", paramsBundle, round)!!
+                                arguments += listOf("--json-report", deliverable(it, seed, singleSample).toString())
                             }
 
                         if (cmd.hasThreadsOption && threadsOption.isSet) {
                             arguments += listOf("--threads", threadsOption.value.toString())
                         }
 
-                        if (cmd.hasUseLocalTempOption && useLocalTemp.value) {
-                            arguments += "--use-local-temp"
+                        if (cmd.hasUseLocalTempOption) {
+                            when (cmd) {
+                                // mitool derives its scratch location from its output rather than
+                                // taking a folder, so it is pointed there by --use-local-temp
+                                is MiToolCommandDelegationDescriptor<*, *> ->
+                                    if (useLocalTemp.value || (intermediate && intermediatesFolder != null))
+                                        arguments += "--use-local-temp"
+
+                                else -> when {
+                                    useLocalTemp.tempDir != null ->
+                                        arguments += listOf("--temp-dir", useLocalTemp.tempDir.toString())
+
+                                    useLocalTemp.value -> arguments += "--use-local-temp"
+
+                                    intermediatesFolder != null ->
+                                        arguments += listOf("--temp-dir", intermediatesFolder.toString())
+                                }
+                            }
                         }
 
                         val outputName = cmd.outputName(outputNamePrefix, inputs.sampleName, paramsBundle, round)
-                        val output = listOf(outputFolder.resolve(outputName).toString())
+                        val outputPath = resolveOutput(outputName, seedName, intermediate, singleSample)
+                        val output = listOf(outputPath.toString())
+
+                        // A pinned file is a deliverable by definition and is never freed
+                        val removable = intermediate && seedName !in outputPaths
+                        if (removable)
+                            removableIntermediates += output.first()
+                        placements[cmd] = StepPlacement(outputPath.parent ?: Path(""), removable)
 
                         executionPlan += ExecutionStep(
                             when (cmd) {

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssemble.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssemble.kt
@@ -49,7 +49,6 @@ import com.milaboratory.util.ArraysUtils
 import com.milaboratory.util.HashFunctions
 import com.milaboratory.util.ReportUtil
 import com.milaboratory.util.SmartProgressReporter
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.use
 import gnu.trove.map.hash.TIntObjectHashMap
 import io.repseq.core.GeneFeature.CDR3
@@ -165,7 +164,7 @@ object CommandAssemble {
         lateinit var useLocalTemp: UseLocalTempOption
 
         private val tempDest by lazy {
-            TempFileManager.smartTempDestination(outputFile, ".tmp.", !useLocalTemp.value)
+            useLocalTemp.tempDestination(outputFile, ".tmp.")
         }
 
         @Option(

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssembleCells.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssembleCells.kt
@@ -37,7 +37,6 @@ import com.milaboratory.mixcr.presets.MiXCRParamsBundle
 import com.milaboratory.mixcr.util.Concurrency
 import com.milaboratory.util.ReportUtil
 import com.milaboratory.util.SmartProgressReporter
-import com.milaboratory.util.TempFileManager
 import io.repseq.core.VDJCLibraryRegistry
 import picocli.CommandLine.Command
 import picocli.CommandLine.Mixin
@@ -150,7 +149,7 @@ object CommandAssembleCells {
 
                 val result = calculateGroupIdForClones(reader.readCloneSet(), reader.header, reportBuilder)
 
-                val tempDest = TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp.value)
+                val tempDest = useLocalTemp.tempDestination(outputFile, "")
                 ClnAWriter(outputFile, tempDest).use { writer ->
                     var newNumberOfAlignments: Long = 0
                     val allAlignmentsList = mutableListOf<OutputPort<VDJCAlignments>>()

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandBAM2fastq.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandBAM2fastq.kt
@@ -18,8 +18,8 @@ import com.milaboratory.core.io.sequence.SingleRead
 import com.milaboratory.core.io.sequence.fastq.PairedFastqWriter
 import com.milaboratory.core.io.sequence.fastq.SingleFastqWriter
 import com.milaboratory.mixcr.bam.BAMReader
-import com.milaboratory.util.TempFileManager
 import picocli.CommandLine.Command
+import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 import java.nio.file.Path
 
@@ -29,12 +29,8 @@ import java.nio.file.Path
     description = ["Converts BAM/SAM file to paired/unpaired fastq files"]
 )
 class CommandBAM2fastq : MiXCRCommandWithOutputs() {
-    @Option(
-        description = ["Put temporary files in the same folder as the output files."],
-        names = ["--use-local-temp"],
-        order = OptionsOrder.localTemp
-    )
-    var useLocalTemp = false
+    @Mixin
+    lateinit var useLocalTemp: UseLocalTempOption
 
     @Option(
         names = ["-b", "--bam"],
@@ -107,7 +103,7 @@ class CommandBAM2fastq : MiXCRCommandWithOutputs() {
         get() = listOf(fastq1, fastq2, fastqUnpaired)
 
     override fun run1() {
-        val tempFileDest = TempFileManager.smartTempDestination(fastq1, "", !useLocalTemp)
+        val tempFileDest = useLocalTemp.tempDestination(fastq1, "")
         BAMReader(
             bamFiles,
             dropNonVDJ,

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandExportShmTreesTableWithNodes.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandExportShmTreesTableWithNodes.kt
@@ -37,7 +37,6 @@ import com.milaboratory.mixcr.trees.forPostanalysis
 import com.milaboratory.mixcr.trees.splitToChains
 import com.milaboratory.util.ComparatorWithHash
 import com.milaboratory.util.TempFileDest
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.groupByOnDisk
 import gnu.trove.set.hash.TIntHashSet
 import io.repseq.core.VDJCLibraryRegistry
@@ -112,9 +111,9 @@ class CommandExportShmTreesTableWithNodes : CommandExportShmTreesAbstract() {
 
     private val tempDest: TempFileDest by lazy {
         ValidationException.requireNotNull(out) {
-            "With --use-local-temp explicit output path is required"
+            "With --temp-dir or --use-local-temp explicit output path is required"
         }
-        TempFileManager.smartTempDestination(out!!, ".build_trees", !useLocalTemp.value)
+        useLocalTemp.tempDestination(out!!, ".build_trees")
     }
 
     override val outputFiles

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandFindAlleles.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandFindAlleles.kt
@@ -196,7 +196,7 @@ class CommandFindAlleles : MiXCRCommandWithOutputs() {
     private val tempDest: TempFileDest by lazy {
         val path = outputFiles.first()
         if (useLocalTemp.value) path.toAbsolutePath().parent.createDirectories()
-        TempFileManager.smartTempDestination(path, ".find_alleles", !useLocalTemp.value)
+        useLocalTemp.tempDestination(path, ".find_alleles")
     }
 
     private val findAllelesParameters: CommandFindAllelesParams by lazy {

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandFindShmTrees.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandFindShmTrees.kt
@@ -61,7 +61,6 @@ import com.milaboratory.util.JsonOverrider
 import com.milaboratory.util.OutputPortWithProgress
 import com.milaboratory.util.ReportUtil
 import com.milaboratory.util.TempFileDest
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.cached
 import com.milaboratory.util.groupByOnDisk
 import com.milaboratory.util.withExpectedSize
@@ -275,7 +274,7 @@ class CommandFindShmTrees : MiXCRCommandWithOutputs() {
 
     private val tempDest: TempFileDest by lazy {
         if (useLocalTemp.value) outputTreesPath.toAbsolutePath().parent.createDirectories()
-        TempFileManager.smartTempDestination(outputTreesPath, ".build_trees", !useLocalTemp.value)
+        useLocalTemp.tempDestination(outputTreesPath, ".build_trees")
     }
 
     override fun run1() {

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandRefineTagsAndSort.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandRefineTagsAndSort.kt
@@ -48,7 +48,6 @@ import com.milaboratory.util.ComparatorWithHash
 import com.milaboratory.util.OutputPortWithProgress
 import com.milaboratory.util.ReportHelper
 import com.milaboratory.util.SmartProgressReporter
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.sortByHashOnDisk
 import org.apache.commons.io.FileUtils
 import picocli.CommandLine.ArgGroup
@@ -212,7 +211,7 @@ object CommandRefineTagsAndSort {
         lateinit var useLocalTemp: UseLocalTempOption
 
         private val tempDest by lazy {
-            TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp.value)
+            useLocalTemp.tempDestination(outputFile, "")
         }
 
         @Option(

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandSlice.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandSlice.kt
@@ -37,7 +37,6 @@ import com.milaboratory.mixcr.basictypes.VDJCAlignmentsWriter
 import com.milaboratory.mixcr.trees.SHMTreesReader
 import com.milaboratory.mixcr.trees.SHMTreesWriter
 import com.milaboratory.mixcr.util.Concurrency
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.exhaustive
 import gnu.trove.set.hash.TLongHashSet
 import io.repseq.core.VDJCLibraryRegistry
@@ -159,7 +158,7 @@ class CommandSlice : MiXCRCommandWithOutputs() {
 
     private fun sliceClnA() {
         ClnAReader(input, VDJCLibraryRegistry.getDefault(), Concurrency.noMoreThan(4)).use { reader ->
-            ClnAWriter(out.toFile(), TempFileManager.smartTempDestination(out, "", !useLocalTemp.value)).use { writer ->
+            ClnAWriter(out.toFile(), useLocalTemp.tempDestination(out, "")).use { writer ->
                 // Getting full clone set
                 val cloneSet = reader.readCloneSet()
 

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandSortAlignments.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandSortAlignments.kt
@@ -23,7 +23,6 @@ import com.milaboratory.mixcr.basictypes.VDJCAlignmentsWriter
 import com.milaboratory.primitivio.PipeReader
 import com.milaboratory.primitivio.PipeWriter
 import com.milaboratory.util.ObjectSerializer
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.sortOnDisk
 import io.repseq.core.VDJCGene
 import picocli.CommandLine.Command
@@ -53,7 +52,7 @@ class CommandSortAlignments : MiXCRCommandWithOutputs() {
         get() = listOf(out)
 
     private val tempDest by lazy {
-        TempFileManager.smartTempDestination(out, "", !useLocalTemp.value)
+        useLocalTemp.tempDestination(out, "")
     }
 
     override fun validate() {

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandSortClones.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandSortClones.kt
@@ -28,7 +28,6 @@ import com.milaboratory.mixcr.basictypes.VDJCSProperties
 import com.milaboratory.mixcr.cli.CommonDescriptions.Labels
 import com.milaboratory.util.ArraysUtils
 import com.milaboratory.util.SmartProgressReporter
-import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.exhaustive
 import io.repseq.core.GeneFeature
 import io.repseq.core.GeneFeature.CDR3
@@ -96,7 +95,7 @@ class CommandSortClones : MiXCRCommandWithOutputs() {
                 VDJCLibraryRegistry.getDefault(),
                 Runtime.getRuntime().availableProcessors()
             ).use { reader ->
-                ClnAWriter(out, TempFileManager.smartTempDestination(out, "", !useLocalTemp.value)).use { writer ->
+                ClnAWriter(out, useLocalTemp.tempDestination(out, "")).use { writer ->
                     SmartProgressReporter.startProgressReport(writer)
                     val ordering = chooseOrdering(reader)
                     writer.writeClones(reader.readCloneSet().reorder(ordering))

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/MiXCRCommand.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/MiXCRCommand.kt
@@ -71,6 +71,8 @@ abstract class MiXCRCommand : Runnable {
         const val overrides = 500_000
 
         const val report = 1_000_000 + 1_000
+        const val intermediates = 1_000_000 + 1_500
+        const val tempDir = 1_000_000 + 1_900
         const val localTemp = 1_000_000 + 2_000
         const val threads = 1_000_000 + 3_000
         const val forceOverride = 1_000_000 + 4_000

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/UseLocalTempOption.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/UseLocalTempOption.kt
@@ -13,9 +13,27 @@ package com.milaboratory.mixcr.cli
 
 import com.milaboratory.app.logger
 import com.milaboratory.mixcr.cli.MiXCRCommand.OptionsOrder
+import com.milaboratory.util.TempFileDest
+import com.milaboratory.util.TempFileManager
 import picocli.CommandLine.Option
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 
 class UseLocalTempOption {
+    @Option(
+        description = ["Put temporary files, such as sort spills, in the specified folder, creating " +
+                "it if needed. In analyze, defaults to the intermediates location when those are " +
+                "relocated, and to the system temp folder otherwise. Takes precedence over " +
+                "--use-local-temp. Steps that MiXCR delegates to mitool do not take a folder: their " +
+                "scratch data sits next to their own output when intermediates are relocated or " +
+                "--use-local-temp is given, and in the system temp folder otherwise."],
+        names = ["--temp-dir"],
+        paramLabel = "<path>",
+        order = OptionsOrder.tempDir
+    )
+    var tempDir: Path? = null
+
     @Option(
         description = ["Put temporary files in the same folder as the output files."],
         names = ["--use-local-temp"],
@@ -35,4 +53,19 @@ class UseLocalTempOption {
                     "behaviour and place temporary files in the same folder as the output file."
         )
     }
+
+    /**
+     * Destination for scratch data of a step writing [outputFile].
+     *
+     * [additionalPrefix] separates the destinations of steps sharing a folder. A destination claims every
+     * file whose name starts with its prefix, so the prefix must not be a prefix of unrelated files.
+     */
+    fun tempDestination(outputFile: Path, additionalPrefix: String): TempFileDest =
+        when (val dir = tempDir) {
+            null -> TempFileManager.smartTempDestination(outputFile, additionalPrefix, !value)
+            else -> {
+                if (!dir.exists()) dir.createDirectories()
+                TempFileDest.filesWithPrefix(dir, "tmp." + outputFile.fileName + additionalPrefix, true)
+            }
+        }
 }


### PR DESCRIPTION
Based on #2133, so this diff is only the CLI feature. Retarget to `develop` once that merges.

## Problem

`analyze` wrote every step's data output next to the final output and freed none of it. A single-cell clonotyping run accumulated ~30 GB of files that no longer had a reader:

```
2.0G  result.consensus.1.mic
1.5G  result.consensus.2.mic
 13G  result.parsed.mic
 12G  result.refined.mic
```

Nothing relocated them. `--use-local-temp` never governed them — it only moves persistent-sort spills.

## Approach

Every produced file gets its path from one precedence chain:

1. an explicit `--output-path <fileName>=<path>` — always wins
2. the intermediates location, for files a later step reads
3. the positional output prefix — everything else, i.e. today's behaviour

An intermediate is a data output that a later step of the resolved pipeline reads, which is every payload file except the last production step's. The pipeline is fully resolved before any step runs, so this needs no per-step metadata and no new descriptor flag. Reports, QC and exports stay with the output files even for intermediate steps — that divergence is the core of the change.

## Options

- `--intermediates-dir <dir>` / `--intermediates-in-temp` — where intermediates go (mutually exclusive)
- `--remove-intermediates` — free each file once nothing reads it. Peak on the run above drops from a growing ~30 GB to the largest adjacent pair
- `--output-path <fileName>=<path>` — pin one file, which makes it a deliverable that is never freed
- `--temp-dir <dir>` — scratch location as its own axis, added to the shared `UseLocalTempOption` mixin and used by all 11 call sites. Defaults to the intermediates location when those are relocated. `--use-local-temp` keeps working unchanged

A name given to `--output-path` that matches nothing the run produces is rejected up front, listing the names that are available — otherwise a typo is a silent no-op, and under `--remove-intermediates` the file the caller meant to keep would be deleted instead.

`qc` is excluded from the terminal-step calculation: it carries the highest non-export order, so with `--add-step qc` it would otherwise stand in for the step that produces the deliverable and the real final `.clns` would become deletable.

## Accepted limitations

- The preprocessing steps delegated to mitool do not take a scratch folder; their scratch sits next to their own output, which is the intermediates location when intermediates are relocated. Stated in `--temp-dir`'s help.
- `--intermediates-in-temp` depends on the system temp folder being provisioned; in a container that is the container's own `/tmp`. Callers who cannot rely on that use `--intermediates-dir`.
- Cleanup rides milib's JVM shutdown hook, so it does not fire on SIGKILL or OOM-kill.

## Tests

`itests/case-intermediates.sh` covers the default layout (the regression guard on the `PlanBuilder` rework), `--intermediates-dir`, `--intermediates-in-temp` with `--remove-intermediates`, both together, `--output-path` surviving removal, sample-split input, and rejection of an unmatched name. CI picks it up as its own job automatically.

Run locally alongside it: the five sample-split cases, `case-base_single_cell`, `case-base_single_cell_fast`, `case-qc`, `case-slice`, `case-bam` and `case-base_build_trees`.

CI was started with `workflow_dispatch`: `on.push.branches` is `['*']`, which does not match a branch name containing `/`.