### PR TITLE
Pass a temp destination to CloneAssembler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,7 @@ val obfuscationLibs: Configuration by configurations.creating
 
 
 
-val mixcrAlgoVersion = "4.7.0-67-develop"
+val mixcrAlgoVersion = "4.7.0-70-develop"
 // may be blank (will be inherited from mixcr-algo)
 val milibVersion = "3.5.0-22-master"
 // may be blank (will be inherited from mixcr-algo or milib)

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssemble.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssemble.kt
@@ -165,7 +165,7 @@ object CommandAssemble {
         lateinit var useLocalTemp: UseLocalTempOption
 
         private val tempDest by lazy {
-            TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp.value)
+            TempFileManager.smartTempDestination(outputFile, ".tmp.", !useLocalTemp.value)
         }
 
         @Option(

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssemble.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssemble.kt
@@ -309,7 +309,8 @@ object CommandAssemble {
                     cloneAssemblerParameters,
                     cmdParam.clnaOutput,
                     alignmentsReader.usedGenes,
-                    inputHeader.featuresToAlignMap
+                    inputHeader.featuresToAlignMap,
+                    tempDest
                 ).use { assembler ->
                     // Creating event listener to collect run statistics
                     reportBuilder.setStartMillis(beginTimestamp)

--- a/src/test/java/com/milaboratory/mixcr/assembler/CloneAssemblerRunnerTest.java
+++ b/src/test/java/com/milaboratory/mixcr/assembler/CloneAssemblerRunnerTest.java
@@ -109,7 +109,8 @@ public class CloneAssemblerRunnerTest {
         CloneAssemblerRunner assemblerRunner = new CloneAssemblerRunner(
                 PreCloneReader.fromAlignments(alignmentsProvider, assemblerParameters.getAssemblingFeatures(), __ -> {
                 }),
-                new CloneAssembler(TagsInfo.NO_TAGS, assemblerParameters, true, aligner.getUsedGenes(), alignerParameters));
+                new CloneAssembler(TagsInfo.NO_TAGS, assemblerParameters, true, aligner.getUsedGenes(), alignerParameters,
+                        TempFileManager.systemTempFolderDestination("test.assemble")));
         SmartProgressReporter.startProgressReport(assemblerRunner);
         assemblerRunner.run();
 


### PR DESCRIPTION
Replaces #2133, which was on a branch whose name contained `/` — that made the docker publish step fail on an invalid tag (`latest-fix/...` is not a valid docker tag) and stopped CI triggering on push. Same commits, slash-free branch name.

Consumes the mixcr-algo change (milaboratory/mixcr-algo#153) that lets the caller decide where the assembler event log lives.

`AssemblerEventLogger` holds the alignment-to-clone assignment ledger — a working file of the assemble step, not a debug artifact. It used to allocate itself in the system temp folder, so `--use-local-temp` could not move it; on a large run that is hundreds of megabytes in a location the caller cannot choose. `assemble` now hands `CloneAssembler` the same temp destination it uses for the rest of its scratch data.

Changes:

- `mixcrAlgoVersion` bumped to `4.7.0-69-fix-assembler-event-logger-temp-dest`.
- `CommandAssemble` passes its existing `tempDest` into `CloneAssembler`; `CloneAssemblerRunnerTest` passes a system-temp destination.
- assemble's temp destination gets its own `.tmp.` name prefix. A destination claims every file whose name starts with its prefix and clears them when it is created; that prefix was the output file name, so the destination also claimed unrelated files next to the output, such as exports from an earlier run. Passing the destination to `CloneAssembler` makes it materialise on every run rather than only for barcoded and clna output, which widened that reach.

**Do not merge with this `mixcrAlgoVersion`.** It is a branch build for validation. Once the mixcr-algo change is on `develop`, re-point the pin at a develop build and let CI go green again.