### PR TITLE
Let analyze place pipeline intermediates away from the output

### DIFF
--- a/itests/case-intermediates.sh
+++ b/itests/case-intermediates.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Placement of pipeline intermediates
+
+assert() {
+  expected=$(echo -ne "${2:-}")
+  result="$(eval 2>/dev/null $1)" || true
+  result="$(sed -e 's/ *$//' -e 's/^ *//' <<<"$result")"
+  if [[ "$result" == "$expected" ]]; then
+    return
+  fi
+  result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<<"$result")"
+  [[ -z "$result" ]] && result="nothing" || result="\"$result\""
+  [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
+  echo "expected $expected got $result for" "$1"
+  exit 1
+}
+
+set -euxo pipefail
+
+R1=single_cell_vdj_t_subset_R1.fastq.gz
+R2=single_cell_vdj_t_subset_R2.fastq.gz
+
+# Default placement: every file lands next to the output
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs "$R1" "$R2" im.default
+
+assert "ls im.default.parsed.mic im.default.refined.mic im.default.alignments.vdjca | wc -l" "3"
+assert "ls im.default.assembledCells.clns im.default.qc.json | wc -l" "2"
+
+# --intermediates-dir moves the files later steps read, and only those
+rm -rf scratch
+mkdir scratch
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs --intermediates-dir ./scratch "$R1" "$R2" im.dir
+
+assert "ls im.dir.*.mic im.dir.*.vdjca im.dir.*.clna | wc -l" "0"
+assert "ls scratch/im.dir.parsed.mic scratch/im.dir.refined.mic scratch/im.dir.alignments.vdjca | wc -l" "3"
+assert "ls im.dir.assembledCells.clns im.dir.qc.txt im.dir.qc.json im.dir.align.report.txt im.dir.align.report.json | wc -l" "5"
+rm -rf scratch
+
+# --intermediates-in-temp leaves only deliverables behind, and owns the folder it used.
+# TMPDIR is set so the test asserts against a temp folder it controls.
+rm -rf tmpcheck
+mkdir tmpcheck
+TMPDIR="$(pwd)/tmpcheck" mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
+  --intermediates-in-temp --remove-intermediates "$R1" "$R2" im.temp
+
+assert "ls im.temp.*.mic im.temp.*.vdjca im.temp.*.clna | wc -l" "0"
+assert "ls im.temp.assembledCells.clns im.temp.qc.json | wc -l" "2"
+assert "find tmpcheck -mindepth 1 | wc -l" "0"
+rm -rf tmpcheck
+
+# A file given an explicit path is a deliverable and outlives --remove-intermediates
+rm -rf tmpcheck
+mkdir tmpcheck
+TMPDIR="$(pwd)/tmpcheck" mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
+  --intermediates-in-temp --remove-intermediates \
+  --output-path im.pin.parsed.mic=./im.pin.kept.mic "$R1" "$R2" im.pin
+
+assert "ls im.pin.kept.mic im.pin.assembledCells.clns | wc -l" "2"
+assert "ls im.pin.*.vdjca | wc -l" "0"
+rm -rf tmpcheck
+
+# --intermediates-dir and --remove-intermediates together: files land in the folder and are
+# freed as the run proceeds
+rm -rf scratch
+mkdir scratch
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
+  --intermediates-dir ./scratch --remove-intermediates "$R1" "$R2" im.both
+
+assert "ls im.both.assembledCells.clns | wc -l" "1"
+assert "find scratch -type f | wc -l" "0"
+rm -rf scratch
+
+# Sample-split input: the list files each step writes hold bare names, so they have to be
+# resolved against the folder that step wrote to
+rm -rf scratch
+mkdir scratch
+mixcr analyze single-cell-as-sample-split --species hs --rna \
+  --floating-left-alignment-boundary --floating-right-alignment-boundary C \
+  --assemble-clonotypes-by CDR3 --assemble-contigs-by-cells \
+  --intermediates-dir ./scratch "$R1" "$R2" im.split
+
+assert "ls im.split.sample0.clns im.split.sample1.clns im.split.sample2.clns | wc -l" "3"
+assert "ls im.split.*.vdjca | wc -l" "0"
+assert "ls scratch/im.split.sample0.alignments.vdjca scratch/im.split.sample1.alignments.vdjca scratch/im.split.sample2.alignments.vdjca | wc -l" "3"
+rm -rf scratch
+
+# A name that matches nothing the run produces is rejected rather than silently ignored. The
+# names are checked before any step runs, so this costs nothing.
+assert "mixcr analyze 10x-sc-xcr-vdj-fast --species hs --output-path im.typo.parsed.micWRONG=./x.mic $R1 $R2 im.typo 2>&1 | grep -c 'does not match any file this run produces'" "1"

--- a/itests/case-intermediates.sh
+++ b/itests/case-intermediates.sh
@@ -24,7 +24,9 @@ R2=single_cell_vdj_t_subset_R2.fastq.gz
 # Default placement: every file lands next to the output
 mixcr analyze 10x-sc-xcr-vdj-fast --species hs "$R1" "$R2" im.default
 
-assert "ls im.default.parsed.mic im.default.refined.mic im.default.alignments.vdjca | wc -l" "3"
+assert "ls im.default.parsed.mic im.default.refined.mic im.default.consensus.1.mic \
+  im.default.consensus.4.mic im.default.alignments.vdjca im.default.refined.vdjca \
+  im.default.clna im.default.contigs.clns | wc -l" "8"
 assert "ls im.default.assembledCells.clns im.default.qc.json | wc -l" "2"
 
 # --intermediates-dir moves the files later steps read, and only those
@@ -32,8 +34,13 @@ rm -rf scratch
 mkdir scratch
 mixcr analyze 10x-sc-xcr-vdj-fast --species hs --intermediates-dir ./scratch "$R1" "$R2" im.dir
 
-assert "ls im.dir.*.mic im.dir.*.vdjca im.dir.*.clna | wc -l" "0"
-assert "ls scratch/im.dir.parsed.mic scratch/im.dir.refined.mic scratch/im.dir.alignments.vdjca | wc -l" "3"
+# every payload name this preset produces, spelled out: a glob like im.dir.*.clna cannot
+# match im.dir.clna, so globbing here passes whatever happens
+assert "ls im.dir.parsed.mic im.dir.refined.mic im.dir.consensus.1.mic im.dir.alignments.vdjca \
+  im.dir.refined.vdjca im.dir.clna im.dir.contigs.clns 2>/dev/null | wc -l" "0"
+assert "ls scratch/im.dir.parsed.mic scratch/im.dir.refined.mic scratch/im.dir.consensus.1.mic \
+  scratch/im.dir.consensus.4.mic scratch/im.dir.alignments.vdjca scratch/im.dir.refined.vdjca \
+  scratch/im.dir.clna scratch/im.dir.contigs.clns | wc -l" "8"
 assert "ls im.dir.assembledCells.clns im.dir.qc.txt im.dir.qc.json im.dir.align.report.txt im.dir.align.report.json | wc -l" "5"
 rm -rf scratch
 
@@ -44,8 +51,11 @@ mkdir tmpcheck
 TMPDIR="$(pwd)/tmpcheck" mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
   --intermediates-in-temp --remove-intermediates "$R1" "$R2" im.temp
 
-assert "ls im.temp.*.mic im.temp.*.vdjca im.temp.*.clna | wc -l" "0"
-assert "ls im.temp.assembledCells.clns im.temp.qc.json | wc -l" "2"
+assert "ls im.temp.parsed.mic im.temp.refined.mic im.temp.consensus.1.mic \
+  im.temp.alignments.vdjca im.temp.refined.vdjca im.temp.clna im.temp.contigs.clns \
+  2>/dev/null | wc -l" "0"
+assert "ls im.temp.assembledCells.clns im.temp.qc.json im.temp.qc.txt \
+  im.temp.align.report.txt im.temp.align.report.json | wc -l" "5"
 assert "find tmpcheck -mindepth 1 | wc -l" "0"
 rm -rf tmpcheck
 
@@ -57,13 +67,12 @@ TMPDIR="$(pwd)/tmpcheck" mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
   --output-path im.pin.parsed.mic=./im.pin.kept.mic "$R1" "$R2" im.pin
 
 assert "ls im.pin.kept.mic im.pin.assembledCells.clns | wc -l" "2"
-assert "ls im.pin.*.vdjca | wc -l" "0"
+assert "ls im.pin.alignments.vdjca im.pin.refined.vdjca 2>/dev/null | wc -l" "0"
 rm -rf tmpcheck
 
 # --intermediates-dir and --remove-intermediates together: files land in the folder and are
-# freed as the run proceeds
+# freed as the run proceeds. The folder is left for MiXCR to create.
 rm -rf scratch
-mkdir scratch
 mixcr analyze 10x-sc-xcr-vdj-fast --species hs \
   --intermediates-dir ./scratch --remove-intermediates "$R1" "$R2" im.both
 
@@ -84,6 +93,15 @@ assert "ls im.split.sample0.clns im.split.sample1.clns im.split.sample2.clns | w
 assert "ls im.split.*.vdjca | wc -l" "0"
 assert "ls scratch/im.split.sample0.alignments.vdjca scratch/im.split.sample1.alignments.vdjca scratch/im.split.sample2.alignments.vdjca | wc -l" "3"
 rm -rf scratch
+
+# --remove-intermediates on its own, with the intermediates left next to the output: the
+# deliverables have to survive being freed alongside them
+mixcr analyze 10x-sc-xcr-vdj-fast --species hs --remove-intermediates "$R1" "$R2" im.here
+
+assert "ls im.here.parsed.mic im.here.refined.mic im.here.alignments.vdjca im.here.clna \
+  im.here.contigs.clns 2>/dev/null | wc -l" "0"
+assert "ls im.here.assembledCells.clns im.here.qc.json im.here.qc.txt \
+  im.here.align.report.txt im.here.clones.tsv | wc -l" "5"
 
 # A name that matches nothing the run produces is rejected rather than silently ignored. The
 # names are checked before any step runs, so this costs nothing.

--- a/regression/cli-help/analyze.txt
+++ b/regression/cli-help/analyze.txt
@@ -31,11 +31,12 @@ Usage: mixcr analyze [--reference-for-cram genome.fasta[.gz]] [--lenient-bam-val
                      [--dont-show-secondary-chain-on-export-cell-groups]
                      [--export-clone-groups-sort-chains-by (Read|Molecule|Auto)] [--no-reports]
                      [--no-json-reports] [--output-not-used-reads] [--strict-sample-sheet-matching]
-                     [--use-local-temp] [--threads <n>] [--force-overwrite] [--no-warnings]
-                     [--verbose] [--help] [-M <key=value>]... [--remove-qc-check <type>
-                     [--remove-qc-check <type>]...]... <preset> ([file_I1.fastq[.gz] [file_I2.fastq
-                     [.gz]]] file_R1.fastq[.gz] [file_R2.fastq[.gz]]|file.(fasta[.gz]
-                     |bam|sam|cram)) output_prefix
+                     [--intermediates-dir <path>] [--intermediates-in-temp]
+                     [--remove-intermediates] [--output-path <name=path>]... [--use-local-temp]
+                     [--threads <n>] [--force-overwrite] [--no-warnings] [--verbose] [--help] [-M
+                     <key=value>]... [--remove-qc-check <type> [--remove-qc-check <type>]...]...
+                     <preset> ([file_I1.fastq[.gz] [file_I2.fastq[.gz]]] file_R1.fastq[.gz]
+                     [file_R2.fastq[.gz]]|file.(fasta[.gz]|bam|sam|cram)) output_prefix
 Run full MiXCR pipeline for specific input.
       <preset>               Name of the analysis preset.
       ([file_I1.fastq[.gz] [file_I2.fastq[.gz]]] file_R1.fastq[.gz] [file_R2.fastq[.gz]]|file.(fasta
@@ -64,6 +65,38 @@ Run full MiXCR pipeline for specific input.
                              Perform strict matching against input sample sheet (one substitution
                                will be allowed by default).
                              This option only valid if input file is *.tsv sample sheet.
+      --intermediates-dir <path>
+                             Write intermediate files to the specified folder instead of next to
+                               the output files, creating it if needed. Intermediates are the step
+                               outputs that later steps read: the .mic and .vdjca files, and any .
+                               clns/.clna produced before the last one. Reports, QC and exports are
+                               unaffected. Scratch data of the relocated steps follows them here;
+                               the last step's stays in the system temp folder. Mutually exclusive
+                               with --intermediates-in-temp.
+      --intermediates-in-temp
+                             Write intermediate files to a folder MiXCR creates inside the system
+                               temp folder and removes when the run exits, including after a failed
+                               step but not if the process is killed outright. The system temp
+                               folder is $TMPDIR when that is set, otherwise the JVM default, which
+                               is normally /tmp; inside a container that is the container's own
+                               /tmp unless $TMPDIR is passed in. It has to have room for the
+                               intermediates. Use --intermediates-dir to choose the location
+                               yourself. Mutually exclusive with --intermediates-dir.
+      --remove-intermediates Delete each intermediate file as soon as the last step that reads it
+                               has finished, so the run holds only what it still needs rather than
+                               every file it has produced. A file given an explicit --output-path
+                               is a deliverable and is never deleted. Recovering from a failed step
+                               means re-running from the input files.
+      --output-path <name=path>
+                             Write one produced file to an explicit path, overriding every other
+                               placement option and making that file a deliverable. The name is the
+                               file name the step produces, as printed with the step's command
+                               while the run executes, e.g. --output-path result.vdjca=/data/result.
+                               vdjca. A name this pipeline does not produce is rejected, listing
+                               the ones it does. Repeat to pin several files. For multi-sample
+                               input use the name produced before the input is split by sample;
+                               with several samples the folder of the path is used and each sample
+                               keeps its own file name.
       --use-local-temp       Put temporary files in the same folder as the output files.
   -t, --threads <n>          Processing threads
   -f, --force-overwrite      Force overwrite of output file(s).

--- a/regression/reports/baseSingleCell.raw.yaml
+++ b/regression/reports/baseSingleCell.raw.yaml
@@ -919,7 +919,7 @@ mitool-parse:
             costDistributions:
               "0": 46879
   trimmerReport: null
-  commandLine: parse --report baseSingleCell.raw.parse.report.txt --preset local:MiTool.preset
+  commandLine: parse --report baseSingleCell.raw.parse.report.txt --preset local:baseSingleCell.raw.MiTool.preset
     --save-output-file-names baseSingleCell.raw.parse.list.tsv single_cell_vdj_t_subset_R1.fastq.gz
     single_cell_vdj_t_subset_R2.fastq.gz baseSingleCell.raw.parsed.mic
   inputFiles:

--- a/regression/reports/baseSingleCell.vdjcontigs.yaml
+++ b/regression/reports/baseSingleCell.vdjcontigs.yaml
@@ -922,7 +922,7 @@ mitool-parse:
               "0": 46879
   trimmerReport: null
   commandLine: parse --report baseSingleCell.vdjcontigs.parse.report.txt --preset
-    local:MiTool.preset --save-output-file-names baseSingleCell.vdjcontigs.parse.list.tsv
+    local:baseSingleCell.vdjcontigs.MiTool.preset --save-output-file-names baseSingleCell.vdjcontigs.parse.list.tsv
     single_cell_vdj_t_subset_R1.fastq.gz single_cell_vdj_t_subset_R2.fastq.gz baseSingleCell.vdjcontigs.parsed.mic
   inputFiles:
     - single_cell_vdj_t_subset_R1.fastq.gz

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAlign.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAlign.kt
@@ -916,7 +916,7 @@ object CommandAlign {
         private var outputFileList: Path? = null
 
         private val tempDest by lazy {
-            TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp)
+            TempFileManager.smartTempDestination(outputFile, ".tmp.", !useLocalTemp)
         }
 
 

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAnalyze.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAnalyze.kt
@@ -13,6 +13,7 @@ package com.milaboratory.mixcr.cli
 
 import com.milaboratory.app.InputFileType
 import com.milaboratory.app.ValidationException
+import com.milaboratory.app.logger
 import com.milaboratory.app.matches
 import com.milaboratory.cli.MultiSampleRun.SAVE_OUTPUT_FILE_NAMES_OPTION
 import com.milaboratory.cli.MultiSampleRun.listToSampleName
@@ -35,6 +36,7 @@ import com.milaboratory.mixcr.presets.MiXCRParamsBundle
 import com.milaboratory.mixcr.presets.MiXCRParamsSpec
 import com.milaboratory.mixcr.presets.MiXCRPipeline
 import com.milaboratory.util.K_YAML_OM
+import com.milaboratory.util.TempFileManager
 import com.milaboratory.util.PathPatternExpandException
 import com.milaboratory.util.parseAndRunAndCorrelateFSPattern
 import picocli.CommandLine.ArgGroup
@@ -46,12 +48,14 @@ import picocli.CommandLine.Model.PositionalParamSpec
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 import java.io.File
+import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
 import kotlin.io.path.name
 import kotlin.io.path.readLines
 import kotlin.system.exitProcess
@@ -225,6 +229,56 @@ object CommandAnalyze {
         private var dryRun: Boolean = false
 
         @Option(
+            description = ["Write intermediate files to the specified folder instead of next to the " +
+                    "output files, creating it if needed. Intermediates are the step outputs that " +
+                    "later steps read: the .mic and .vdjca files, and any .clns/.clna produced " +
+                    "before the last one. Reports, QC and exports are unaffected. Scratch data " +
+                    "follows the intermediates here. Mutually exclusive with --intermediates-in-temp."],
+            names = ["--intermediates-dir"],
+            paramLabel = "<path>",
+            order = OptionsOrder.intermediates
+        )
+        private var intermediatesDir: Path? = null
+
+        @Option(
+            description = ["Write intermediate files to a folder MiXCR creates inside the system " +
+                    "temp folder and removes when the run exits, including after a failed step but " +
+                    "not if the process is killed outright. The system temp folder is \$TMPDIR when " +
+                    "that is set, otherwise the JVM default, which is normally /tmp; inside a " +
+                    "container that is the container's own /tmp unless \$TMPDIR is passed in. It has " +
+                    "to have room for the intermediates. Use --intermediates-dir to choose the " +
+                    "location yourself. Mutually exclusive with --intermediates-dir."],
+            names = ["--intermediates-in-temp"],
+            order = OptionsOrder.intermediates + 1
+        )
+        private var intermediatesInTemp: Boolean = false
+
+        @Option(
+            description = ["Delete each intermediate file as soon as the last step that reads it " +
+                    "has finished, so the run holds only what it still needs rather than every file " +
+                    "it has produced. A file given an explicit --output-path is a deliverable and is " +
+                    "never deleted. Recovering from a failed step means re-running from the input files."],
+            names = ["--remove-intermediates"],
+            order = OptionsOrder.intermediates + 2
+        )
+        private var removeIntermediates: Boolean = false
+
+        @Option(
+            description = ["Write one produced file to an explicit path, overriding every other " +
+                    "placement option and making that file a deliverable. The name is the file name " +
+                    "the step produces, as printed with the step's command while the run executes, " +
+                    "e.g. --output-path result.vdjca=/data/result.vdjca. A name this pipeline does " +
+                    "not produce is rejected, listing the ones it does. Repeat to pin several files. " +
+                    "For multi-sample input use the name produced before the input is split by " +
+                    "sample; with several samples the folder of the path is used and each sample " +
+                    "keeps its own file name."],
+            names = ["--output-path"],
+            paramLabel = "<name=path>",
+            order = OptionsOrder.intermediates + 3
+        )
+        private var outputPaths: Map<String, Path> = mutableMapOf()
+
+        @Option(
             description = ["Don't output report files for each of the steps"],
             names = ["--no-reports"],
             order = OptionsOrder.report + 100
@@ -325,6 +379,14 @@ object CommandAnalyze {
 
             if (strictMatching && inputSampleSheet == null)
                 throw ValidationException("$STRICT_SAMPLE_NAME_MATCHING_OPTION is valid only with sample sheet input, i.e. a *.tsv file.")
+
+            if (intermediatesDir != null && intermediatesInTemp)
+                throw ValidationException("--intermediates-dir and --intermediates-in-temp are mutually exclusive.")
+
+            intermediatesDir?.let { dir ->
+                if (dir.exists() && !dir.isDirectory())
+                    throw ValidationException("--intermediates-dir is not a folder: $dir")
+            }
         }
 
         override fun run0() {
@@ -355,10 +417,53 @@ object CommandAnalyze {
             if (pipeline.first() !in arrayOf(align, parse))
                 throw ValidationException("Pipeline must stat from the `align` or `parse` action.")
 
+            // Folder for the files later steps consume; null keeps them next to the output files
+            val intermediatesFolder: Path? = when {
+                intermediatesInTemp -> TempFileManager.newTempDir().toPath()
+                else -> intermediatesDir?.also { if (!it.exists()) it.createDirectories() }
+            }
+
+            // Exports and qc read a production step's output, they don't extend the chain, so the
+            // last production step is the one whose output nothing else consumes
+            val terminalStep = pipeline
+                .filterNot { it is AnalyzeCommandDescriptor.ExportCommandDescriptor<*> }
+                .filterNot { it == AnalyzeCommandDescriptor.qc }
+                .last()
+
+            // Every name --output-path can address, taken before the input is split by sample. A
+            // name that matches nothing would otherwise be a silent no-op, and under
+            // --remove-intermediates the file the caller meant to keep would be deleted instead.
+            val producibleNames = if (outputPaths.isEmpty()) emptySet() else buildSet {
+                val qcStep = AnalyzeCommandDescriptor.qc
+                    .takeIf { bundle.qc?.checks?.isNotEmpty() == true && it !in pipeline }
+                (pipeline + listOfNotNull(qcStep)).forEach { cmd ->
+                    val rounds = (cmd as? AllowedMultipleRounds)?.roundsCount(bundle) ?: 1
+                    repeat(rounds) { round ->
+                        val outputName = cmd.outputName(outputNamePrefix, "", bundle, round)
+                        if (cmd == AnalyzeCommandDescriptor.qc) {
+                            val base = outputName.substring(0, outputName.lastIndexOf('.'))
+                            add("$base.txt")
+                            add("$base.json")
+                        } else
+                            add(outputName)
+                        cmd.textReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
+                        cmd.jsonReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
+                    }
+                }
+            }
+            val unknownPins = outputPaths.keys - producibleNames
+            if (unknownPins.isNotEmpty())
+                throw ValidationException(
+                    "--output-path does not match any file this run produces: " +
+                            "${unknownPins.sorted().joinToString(", ")}. " +
+                            "Available: ${producibleNames.sorted().joinToString(", ")}"
+                )
+
             val planBuilder = PlanBuilder(
                 bundle, outputFolder, outputNamePrefix,
                 !noReports, !noJsonReports,
-                inputTemplates, threadsOption, useLocalTemp, forceOverwrite
+                inputTemplates, threadsOption, useLocalTemp, forceOverwrite,
+                intermediatesFolder, outputPaths, removeIntermediates, terminalStep
             )
 
             if (pipeline.first() == parse) {
@@ -383,19 +488,26 @@ object CommandAnalyze {
                         addNotParsed = false
                     )
                 }
-                val mitoolPresetPath = Paths.get("MiTool.preset.yaml").toFile()
-                mitoolPresetPath.deleteOnExit()
-                K_YAML_OM.writeValue(mitoolPresetPath, mitoolPreset)
+                // mitool resolves a local: name against its own search path, which includes the
+                // working directory, and Path.resolve returns an absolute argument unchanged, so
+                // this path works either relative or absolute. It is passed on exactly as given:
+                // resolving it against the working directory would put that directory into the
+                // command line recorded in every output header, and two runs of the same analysis
+                // from different folders would stop producing identical files.
+                val mitoolPresetPath = (intermediatesFolder ?: outputFolder)
+                    .resolve("${outputNamePrefix.dotAfterIfNotBlank()}MiTool.preset.yaml")
+                mitoolPresetPath.toFile().deleteOnExit()
+                K_YAML_OM.writeValue(mitoolPresetPath.toFile(), mitoolPreset)
 
                 // Adding an option to save output files by parse
-                val sampleFileList = outputFolder
+                val sampleFileList = (intermediatesFolder ?: outputFolder)
                     .resolve("${outputNamePrefix.dotAfterIfNotBlank()}parse.list.tsv")
                     .also { it.deleteIfExists() }
                     .toFile().also { it.deleteOnExit() }
 
                 planBuilder.addStep(parse) { _, _, _ ->
                     buildList {
-                        this += listOf("--preset", "local:${mitoolPresetPath.name.removeSuffix(".yaml")}")
+                        this += listOf("--preset", "local:${mitoolPresetPath.toString().removeSuffix(".yaml")}")
                         this += listOf(SAVE_OUTPUT_FILE_NAMES_OPTION, sampleFileList.toString())
                         this += pathsForNotAligned.argsOfNotParsedForMiToolParse()
                     }
@@ -403,7 +515,7 @@ object CommandAnalyze {
 
                 planBuilder.executeSteps(dryRun)
                 // Taking into account that there are multiple outputs from the mitool parse command.
-                planBuilder.setActualOutputs(sampleFileList.toPath())
+                planBuilder.setActualOutputs(parse, sampleFileList.toPath())
 
                 pipeline
                     .drop(1) // without parse
@@ -425,7 +537,7 @@ object CommandAnalyze {
                     this += listOf("--preset", presetName)
                     if (bundle.align!!.splitBySample && !dryRun) {
                         // Adding an option to save output files by align
-                        val sampleFileList = outputFolder
+                        val sampleFileList = (intermediatesFolder ?: outputFolder)
                             .resolve("${outputNamePrefix.dotAfterIfNotBlank()}${sampleName.dotAfterIfNotBlank()}align.list.tsv")
                             .also { it.deleteIfExists() }
                             .toFile().also { it.deleteOnExit() }
@@ -454,7 +566,7 @@ object CommandAnalyze {
             // Taking into account that there are multiple outputs from the align command.
             // Even so, mitool could split into several files and then align could split each too
             if (sampleFileListFiles.isNotEmpty()) {
-                planBuilder.setActualOutputs(sampleFileListFiles)
+                planBuilder.setActualOutputs(align, sampleFileListFiles)
             }
 
             // Adding all steps with calculations
@@ -526,24 +638,85 @@ object CommandAnalyze {
             initialInputs: List<Path>,
             private val threadsOption: ThreadsOption,
             private val useLocalTemp: UseLocalTempOption,
-            private val forceOverride: Boolean
+            private val forceOverride: Boolean,
+            private val intermediatesFolder: Path?,
+            private val outputPaths: Map<String, Path>,
+            private val removeIntermediates: Boolean,
+            private val terminalStep: AnalyzeCommandDescriptor<*, *>
         ) {
             private val executionPlan = mutableListOf<ExecutionStep>()
             private var nextInputs: List<InputFileSet> = listOf(InputFileSet("", initialInputs.map { it.toString() }))
             private val outputsForCommands = mutableListOf<Pair<AnalyzeCommandDescriptor<*, *>, List<InputFileSet>>>()
 
-            fun setActualOutputs(outputFilesList: Path) {
-                setActualOutputs(mapOf("" to outputFilesList))
+            /** Produced files that are safe to delete once no planned step reads them any more */
+            private val removableIntermediates = mutableSetOf<String>()
+
+            /** Where each command put its outputs, for resolving the file names it reported */
+            private val placements = mutableMapOf<AnalyzeCommandDescriptor<*, *>, StepPlacement>()
+
+            private class StepPlacement(val folder: Path, val removable: Boolean)
+
+            /**
+             * Output of every step but the last production one is read further down the pipeline. Rounds of
+             * one command chain the same way, so only the last round of the last command is a deliverable.
+             */
+            private fun isIntermediate(cmd: AnalyzeCommandDescriptor<*, *>, round: Int, roundsCount: Int) =
+                cmd != terminalStep || round != roundsCount - 1
+
+            /**
+             * Path pinned by --output-path, if any.
+             *
+             * Pins are keyed by [seedName], the name the step produces before the input is split by
+             * sample, so one key addresses a step rather than one sample of it. A single path cannot
+             * hold several samples, so with more than one it contributes its folder and each sample
+             * keeps its own name.
+             */
+            private fun pinned(actualName: String, seedName: String, singleSample: Boolean): Path? =
+                outputPaths[seedName]?.let { pinned ->
+                    if (singleSample) pinned else (pinned.parent ?: Path("")).resolve(actualName)
+                }
+
+            /** Files that stay with the output files, unless pinned */
+            private fun deliverable(actualName: String, seedName: String, singleSample: Boolean): Path =
+                pinned(actualName, seedName, singleSample) ?: outputFolder.resolve(actualName)
+
+            /**
+             * The precedence chain: an explicit --output-path wins, then the intermediates folder for
+             * anything read further down the pipeline, then the positional output prefix.
+             */
+            private fun resolveOutput(
+                actualName: String,
+                seedName: String,
+                intermediate: Boolean,
+                singleSample: Boolean
+            ): Path {
+                pinned(actualName, seedName, singleSample)?.let { return it }
+                val folder = if (intermediate) intermediatesFolder ?: outputFolder else outputFolder
+                return folder.resolve(actualName)
             }
 
-            fun setActualOutputs(outputFilesList: Map<String, Path>) {
+            fun setActualOutputs(cmd: AnalyzeCommandDescriptor<*, *>, outputFilesList: Path) {
+                setActualOutputs(cmd, mapOf("" to outputFilesList))
+            }
+
+            /**
+             * Replaces the planned output of [cmd] with the files it actually wrote, one per sample.
+             *
+             * The list files hold bare file names, written as siblings of the output the step was given,
+             * so they resolve against the folder that step wrote to rather than the output prefix.
+             */
+            fun setActualOutputs(cmd: AnalyzeCommandDescriptor<*, *>, outputFilesList: Map<String, Path>) {
+                val placement = placements.getValue(cmd)
                 nextInputs = outputFilesList.flatMap { (prefix, file) ->
                     val withoutHeader = file.readLines().drop(1)
                     withoutHeader.map { it.split("\t") }.map { line ->
                         val sampleName = listToSampleName(line.drop(2))
+                        val output = placement.folder.resolve(line[0]).toString()
+                        if (placement.removable)
+                            removableIntermediates += output
                         InputFileSet(
                             "${prefix.dotAfterIfNotBlank()}$sampleName",
-                            listOf(outputFolder.resolve(line[0]).toString())
+                            listOf(output)
                         )
                     }
                 }
@@ -554,8 +727,20 @@ object CommandAnalyze {
                     // Printing commands that would have been executed
                     executionPlan.forEach { pe -> println(pe) }
                 } else {
+                    // A file is freed after the last step of this batch that reads it, so one that an
+                    // export or QC step still reads outlives the production step that consumed it.
+                    // Readers of a given file are always planned in the same batch as each other.
+                    val lastReaderOf = mutableMapOf<String, Int>()
+                    if (removeIntermediates)
+                        executionPlan.forEachIndexed { index, step ->
+                            step.inputs
+                                .filter { it in removableIntermediates }
+                                .forEach { lastReaderOf[it] = index }
+                        }
+                    val freeAfter = lastReaderOf.entries.groupBy({ it.value }, { it.key })
+
                     // Executing the plan
-                    for (executionStep in executionPlan) {
+                    executionPlan.forEachIndexed { index, executionStep ->
                         println("\n" + Util.surround("mixcr ${executionStep.command}", ">", "<"))
                         println("Running:")
                         println(executionStep)
@@ -564,6 +749,13 @@ object CommandAnalyze {
                         if (exitCode != 0)
                         // Terminating execution if one of the steps resulted in error
                             exitProcess(exitCode)
+                        freeAfter[index]?.forEach { file ->
+                            try {
+                                Path(file).deleteIfExists()
+                            } catch (e: IOException) {
+                                logger.warn("Can't remove intermediate file $file: ${e.message}")
+                            }
+                        }
                     }
                 }
 
@@ -575,6 +767,7 @@ object CommandAnalyze {
 
             fun addQC() {
                 val inputsForQc = outputsForCommands.findLast { (command) -> command.outputSupportsQc }!!.second
+                val singleSample = inputsForQc.size == 1
                 for (input in inputsForQc) {
                     check(input.fileNames.size == 1)
                     val round = 0
@@ -590,10 +783,21 @@ object CommandAnalyze {
                         arguments,
                         emptyList(),
                         listOf(input.fileNames.first()),
-                        listOf(
-                            outputFolder.resolve(outputName.removeExtension() + ".txt").toString(),
-                            outputFolder.resolve(outputName.removeExtension() + ".json").toString()
-                        )
+                        run {
+                            val seed = cmd.outputName(outputNamePrefix, "", paramsBundle, round)
+                            listOf(
+                                deliverable(
+                                    outputName.removeExtension() + ".txt",
+                                    seed.removeExtension() + ".txt",
+                                    singleSample
+                                ).toString(),
+                                deliverable(
+                                    outputName.removeExtension() + ".json",
+                                    seed.removeExtension() + ".json",
+                                    singleSample
+                                ).toString()
+                            )
+                        }
                     )
                 }
             }
@@ -602,6 +806,7 @@ object CommandAnalyze {
                 val runAfter = cmd.runAfterLastOf()
                 // if there is nothing to run on (production command is removed), don't run it
                 val (_, inputsForExport) = outputsForCommands.findLast { (cmd) -> cmd in runAfter } ?: return
+                val singleSample = inputsForExport.size == 1
                 for (input in inputsForExport) {
                     check(input.fileNames.size == 1)
                     val round = 0
@@ -617,7 +822,13 @@ object CommandAnalyze {
                         arguments,
                         emptyList(),
                         listOf(input.fileNames.first()),
-                        listOf(outputFolder.resolve(outputName).toString())
+                        listOf(
+                            deliverable(
+                                outputName,
+                                cmd.outputName(outputNamePrefix, "", paramsBundle, round),
+                                singleSample
+                            ).toString()
+                        )
                     )
                 }
             }
@@ -629,6 +840,9 @@ object CommandAnalyze {
                 val roundsCount = (cmd as? AllowedMultipleRounds)?.roundsCount(paramsBundle) ?: 1
 
                 repeat(roundsCount) { round ->
+                    val intermediate = isIntermediate(cmd, round, roundsCount)
+                    val seedName = cmd.outputName(outputNamePrefix, "", paramsBundle, round)
+                    val singleSample = nextInputs.size == 1
 
                     val nextInputsBuilder = mutableListOf<InputFileSet>()
 
@@ -638,26 +852,42 @@ object CommandAnalyze {
                         if (forceOverride && cmd !is MiToolCommandDelegationDescriptor<*, *>)
                             arguments += "-f"
 
+                        // Reports are deliverables even for a step whose data output is an intermediate,
+                        // so they stay with the output files while the data output moves
                         if (outputReports)
                             cmd.textReportName(outputNamePrefix, inputs.sampleName, paramsBundle, round)?.let {
-                                arguments += listOf("--report", outputFolder.resolve(it).toString())
+                                val seed = cmd.textReportName(outputNamePrefix, "", paramsBundle, round)!!
+                                arguments += listOf("--report", deliverable(it, seed, singleSample).toString())
                             }
 
                         if (outputJsonReports)
                             cmd.jsonReportName(outputNamePrefix, inputs.sampleName, paramsBundle, round)?.let {
-                                arguments += listOf("--json-report", outputFolder.resolve(it).toString())
+                                val seed = cmd.jsonReportName(outputNamePrefix, "", paramsBundle, round)!!
+                                arguments += listOf("--json-report", deliverable(it, seed, singleSample).toString())
                             }
 
                         if (cmd.hasThreadsOption && threadsOption.isSet) {
                             arguments += listOf("--threads", threadsOption.value.toString())
                         }
 
-                        if (cmd.hasUseLocalTempOption && useLocalTemp.value) {
+                        // Every step places its scratch data next to its own output, which is the
+                        // intermediates location when those are relocated. Steps take no scratch
+                        // folder of their own, so this is the only way to move it, and it is the
+                        // same for the steps delegated to mitool as for MiXCR's own.
+                        if (cmd.hasUseLocalTempOption &&
+                            (useLocalTemp.value || (intermediate && intermediatesFolder != null))
+                        )
                             arguments += "--use-local-temp"
-                        }
 
                         val outputName = cmd.outputName(outputNamePrefix, inputs.sampleName, paramsBundle, round)
-                        val output = listOf(outputFolder.resolve(outputName).toString())
+                        val outputPath = resolveOutput(outputName, seedName, intermediate, singleSample)
+                        val output = listOf(outputPath.toString())
+
+                        // A pinned file is a deliverable by definition and is never freed
+                        val removable = intermediate && seedName !in outputPaths
+                        if (removable)
+                            removableIntermediates += output.first()
+                        placements[cmd] = StepPlacement(outputPath.parent ?: Path(""), removable)
 
                         executionPlan += ExecutionStep(
                             when (cmd) {

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAnalyze.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAnalyze.kt
@@ -232,8 +232,9 @@ object CommandAnalyze {
             description = ["Write intermediate files to the specified folder instead of next to the " +
                     "output files, creating it if needed. Intermediates are the step outputs that " +
                     "later steps read: the .mic and .vdjca files, and any .clns/.clna produced " +
-                    "before the last one. Reports, QC and exports are unaffected. Scratch data " +
-                    "follows the intermediates here. Mutually exclusive with --intermediates-in-temp."],
+                    "before the last one. Reports, QC and exports are unaffected. Scratch data of " +
+                    "the relocated steps follows them here; the last step's stays in the system " +
+                    "temp folder. Mutually exclusive with --intermediates-in-temp."],
             names = ["--intermediates-dir"],
             paramLabel = "<path>",
             order = OptionsOrder.intermediates
@@ -439,18 +440,36 @@ object CommandAnalyze {
                 (pipeline + listOfNotNull(qcStep)).forEach { cmd ->
                     val rounds = (cmd as? AllowedMultipleRounds)?.roundsCount(bundle) ?: 1
                     repeat(rounds) { round ->
-                        val outputName = cmd.outputName(outputNamePrefix, "", bundle, round)
+                        // A step the bundle carries no parameters for produces nothing to address,
+                        // and asking it for a name throws. The pipeline tolerates such a step
+                        // elsewhere, so listing the names must not be what breaks the run.
+                        val outputName = try {
+                            cmd.outputName(outputNamePrefix, "", bundle, round)
+                        } catch (e: RuntimeException) {
+                            return@repeat
+                        }
                         if (cmd == AnalyzeCommandDescriptor.qc) {
                             val base = outputName.substring(0, outputName.lastIndexOf('.'))
                             add("$base.txt")
                             add("$base.json")
                         } else
                             add(outputName)
-                        cmd.textReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
-                        cmd.jsonReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
+                        if (!noReports)
+                            cmd.textReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
+                        if (!noJsonReports)
+                            cmd.jsonReportName(outputNamePrefix, "", bundle, round)?.let { add(it) }
                     }
                 }
             }
+            outputPaths.entries.groupBy({ it.value }, { it.key })
+                .filterValues { it.size > 1 }
+                .forEach { (path, names) ->
+                    throw ValidationException(
+                        "--output-path sends ${names.sorted().joinToString(" and ")} to the same " +
+                                "path $path"
+                    )
+                }
+
             val unknownPins = outputPaths.keys - producibleNames
             if (unknownPins.isNotEmpty())
                 throw ValidationException(
@@ -490,10 +509,12 @@ object CommandAnalyze {
                 }
                 // mitool resolves a local: name against its own search path, which includes the
                 // working directory, and Path.resolve returns an absolute argument unchanged, so
-                // this path works either relative or absolute. It is passed on exactly as given:
-                // resolving it against the working directory would put that directory into the
-                // command line recorded in every output header, and two runs of the same analysis
-                // from different folders would stop producing identical files.
+                // this path works either relative or absolute. It is passed on exactly as given
+                // rather than resolved, because it is recorded in the command line of every
+                // downstream file header: keeping it relative is what lets two runs of the same
+                // analysis in different folders produce identical files. Relocating the
+                // intermediates puts that location in the header instead, which is the caller's
+                // choice to make.
                 val mitoolPresetPath = (intermediatesFolder ?: outputFolder)
                     .resolve("${outputNamePrefix.dotAfterIfNotBlank()}MiTool.preset.yaml")
                 mitoolPresetPath.toFile().deleteOnExit()
@@ -870,10 +891,13 @@ object CommandAnalyze {
                             arguments += listOf("--threads", threadsOption.value.toString())
                         }
 
-                        // Every step places its scratch data next to its own output, which is the
-                        // intermediates location when those are relocated. Steps take no scratch
-                        // folder of their own, so this is the only way to move it, and it is the
-                        // same for the steps delegated to mitool as for MiXCR's own.
+                        // A step whose output was relocated puts its scratch data next to that
+                        // output, so the scratch follows the intermediates. Steps take no scratch
+                        // folder of their own, which makes this the only mechanism available, and
+                        // it is the same for the steps delegated to mitool as for MiXCR's own.
+                        // The last step is left alone: its output is a deliverable at the output
+                        // prefix, and its scratch belongs in the system temp folder rather than
+                        // next to the results.
                         if (cmd.hasUseLocalTempOption &&
                             (useLocalTemp.value || (intermediate && intermediatesFolder != null))
                         )

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssembleCells.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandAssembleCells.kt
@@ -150,7 +150,7 @@ object CommandAssembleCells {
 
                 val result = calculateGroupIdForClones(reader.readCloneSet(), reader.header, reportBuilder)
 
-                val tempDest = TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp.value)
+                val tempDest = TempFileManager.smartTempDestination(outputFile, ".tmp.", !useLocalTemp.value)
                 ClnAWriter(outputFile, tempDest).use { writer ->
                     var newNumberOfAlignments: Long = 0
                     val allAlignmentsList = mutableListOf<OutputPort<VDJCAlignments>>()

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/CommandRefineTagsAndSort.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/CommandRefineTagsAndSort.kt
@@ -212,7 +212,7 @@ object CommandRefineTagsAndSort {
         lateinit var useLocalTemp: UseLocalTempOption
 
         private val tempDest by lazy {
-            TempFileManager.smartTempDestination(outputFile, "", !useLocalTemp.value)
+            TempFileManager.smartTempDestination(outputFile, ".tmp.", !useLocalTemp.value)
         }
 
         @Option(

--- a/src/main/kotlin/com/milaboratory/mixcr/cli/MiXCRCommand.kt
+++ b/src/main/kotlin/com/milaboratory/mixcr/cli/MiXCRCommand.kt
@@ -71,6 +71,7 @@ abstract class MiXCRCommand : Runnable {
         const val overrides = 500_000
 
         const val report = 1_000_000 + 1_000
+        const val intermediates = 1_000_000 + 1_500
         const val localTemp = 1_000_000 + 2_000
         const val threads = 1_000_000 + 3_000
         const val forceOverride = 1_000_000 + 4_000


### PR DESCRIPTION
Replaces #2137, which GitHub closed automatically when its base branch was deleted on merging #2136. Same branch and commits, now based on `develop`.

## Problem

`analyze` wrote every step's data output next to the final output and freed none of it. A single-cell clonotyping run accumulated ~30 GB of files that no longer had a reader:

```
2.0G  result.consensus.1.mic
1.5G  result.consensus.2.mic
 13G  result.parsed.mic
 12G  result.refined.mic
```

Nothing relocated them. `--use-local-temp` never governed them — it only moves persistent-sort spills.

## Approach

Every produced file gets its path from one precedence chain:

1. an explicit `--output-path <fileName>=<path>` — always wins
2. the intermediates location, for files a later step reads
3. the positional output prefix — everything else, i.e. today's behaviour

An intermediate is a data output that a later step of the resolved pipeline reads, which is every payload file except the last production step's. The pipeline is fully resolved before any step runs, so this needs no per-step metadata and no new descriptor flag. Reports, QC and exports stay with the output files even for intermediate steps — that divergence is the core of the change.

## Options

- `--intermediates-dir <dir>` / `--intermediates-in-temp` — where intermediates go (mutually exclusive)
- `--remove-intermediates` — free each file once nothing reads it. Peak on the run above drops from a growing ~30 GB to the largest adjacent pair
- `--output-path <fileName>=<path>` — pin one file, which makes it a deliverable that is never freed. A name the pipeline does not produce is rejected up front, listing the ones it does; two pins to the same path are rejected too

## Scratch data

A step whose output was relocated places its scratch next to that output, so the scratch follows the intermediates. This is done by forwarding `--use-local-temp`, and it is deliberately **identical for the steps delegated to mitool and for MiXCR's own** — mitool takes no scratch folder of its own, so this is the only mechanism available to either. The last step is left alone: its output is a deliverable at the output prefix, and its scratch belongs in the system temp folder rather than next to the results.

The default stays the system temp folder, which honours `TMPDIR`, so one env var still governs every step uniformly.

Three temp destinations gained a `.tmp.` name separator (`assemble`, `align`, `refineTagsAndSort`, `assembleCells`). A destination claims every file whose name starts with its prefix and clears them when it is created; that prefix was the output file name, so it also reached files sitting beside the output. `analyze` now points these steps at their own output automatically, which widened that reach.

`qc` is excluded from the terminal-step calculation: it carries the highest non-export order, so with `--add-step qc` it would otherwise stand in for the step that produces the deliverable and the real final `.clns` would become deletable.

The MiTool preset path is passed to mitool exactly as given, relative when the intermediates folder is relative. Resolving it against the working directory would put that directory into the `commandLine` recorded in every output header, and two runs of the same analysis from different folders would stop producing identical files — which is what `case-single_cell_reproducible_hash` checks.

## Accepted limitations

- `--intermediates-in-temp` depends on the system temp folder being provisioned; in a container that is the container's own `/tmp` unless `TMPDIR` is passed in. Callers who cannot rely on that use `--intermediates-dir`.
- Cleanup rides milib's JVM shutdown hook, so it does not fire on SIGKILL or OOM-kill.
- Re-running into the same `--intermediates-dir` needs `-f`, as it would for the output files.

## Tests

`itests/case-intermediates.sh` covers the default layout (the regression guard on the `PlanBuilder` rework), `--intermediates-dir`, `--intermediates-in-temp` with `--remove-intermediates`, both together, `--remove-intermediates` with no relocation at all, `--output-path` surviving removal, sample-split input, and the rejected name. Payload names are spelled out rather than globbed, because a wildcard between two dots cannot match a name with nothing between them and such assertions pass whatever happens.

Reviewed independently across all three PRs after the final state was reached; findings addressed in the second commit.